### PR TITLE
Explicitly call dispose on obsolete connection objects

### DIFF
--- a/NModbus/Device/ModbusTcpSlaveNetwork.cs
+++ b/NModbus/Device/ModbusTcpSlaveNetwork.cs
@@ -200,6 +200,7 @@ namespace NModbus.Device
                 throw new ArgumentException(msg);
             }
 
+            connection.Dispose();
             Logger.Information($"Removed Master {e.EndPoint}");
         }
     }


### PR DESCRIPTION
When using this package on dotnetcore for linux, I found that the underlying filedescriptors are not closed. That is:

If you open and close a lot of connections, 
then lsof -p \`pidof dotnet\` will show many open TCP sockets.