### PR TITLE
Allow to create ModbusIpMaster from IStreamResource

### DIFF
--- a/NModbus/Interfaces/IModbusFactory.cs
+++ b/NModbus/Interfaces/IModbusFactory.cs
@@ -44,6 +44,13 @@ namespace NModbus
         /// <returns></returns>
         IModbusMaster CreateMaster(TcpClient client);
 
+        /// <summary>
+        /// Create an IP master from IStreamResource
+        /// </summary>
+        /// <param name="streamResource">IStreamResource transport</param>
+        /// <returns></returns>
+        IModbusMaster CreateIpMaster(IStreamResource streamResource);
+
         #endregion
 
         #region Slave

--- a/NModbus/ModbusFactory.cs
+++ b/NModbus/ModbusFactory.cs
@@ -136,16 +136,19 @@ namespace NModbus
         {
             var adapter = new UdpClientAdapter(client);
 
-            var transport = new ModbusIpTransport(adapter, this, Logger);
-
-            return new ModbusIpMaster(transport);
+            return CreateIpMaster(adapter);
         }
 
         public IModbusMaster CreateMaster(TcpClient client)
         {
             var adapter = new TcpClientAdapter(client);
 
-            var transport = new ModbusIpTransport(adapter, this, Logger);
+            return CreateIpMaster(adapter);
+        }
+
+        public IModbusMaster CreateIpMaster(IStreamResource streamResource)
+        {
+            var transport = new ModbusIpTransport(streamResource, this, Logger);
 
             return new ModbusIpMaster(transport);
         }


### PR DESCRIPTION
I've created IStreamResource adapters for TcpClient, that automatially reconnects on errors or can connect to other addresses, but I can't create ModbusIpMaster from IStreamResource, that is very confusing.