### PR TITLE
Added Socket adapter for RS385 to ethernet converters.

### DIFF
--- a/NModbus/IO/SocketAdapter.cs
+++ b/NModbus/IO/SocketAdapter.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Diagnostics;
+using System.Net.Sockets;
+using System.Threading;
+using NModbus.Unme.Common;
+
+namespace NModbus.IO
+{
+    /// <summary>
+    ///     Concrete Implementor - http://en.wikipedia.org/wiki/Bridge_Pattern
+    ///     This implementation is for sockets that Convert Rs485 to Ethernet.
+    /// </summary>
+    public class SocketAdapter : IStreamResource
+    {
+        private Socket _socketClient;
+
+        public SocketAdapter(Socket socketClient)
+        {
+            Debug.Assert(socketClient != null, "Argument socketClient van not be null");
+            _socketClient = socketClient;
+        }
+
+        public int InfiniteTimeout => Timeout.Infinite;
+        public int ReadTimeout 
+        { 
+            get => _socketClient.SendTimeout;
+            set => _socketClient.SendTimeout = value;
+
+        }
+        public int WriteTimeout
+        {
+            get => _socketClient.ReceiveTimeout;
+            set => _socketClient.ReceiveTimeout = value;
+        }
+        public void DiscardInBuffer()
+        {
+            // socket does not hold buffers.
+            return;
+        }
+
+        public int Read(byte[] buffer, int offset, int size)
+        {
+            
+            return _socketClient.Receive(buffer,offset,size,0);
+        }
+
+        public void Write(byte[] buffer, int offset, int size)
+        {
+            _socketClient.Send(buffer,offset,size,0);
+        }
+
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                DisposableUtility.Dispose(ref _socketClient);
+            }
+        }
+    }
+}

--- a/NModbus/ModbusFactory.cs
+++ b/NModbus/ModbusFactory.cs
@@ -150,6 +150,15 @@ namespace NModbus
             return new ModbusIpMaster(transport);
         }
 
+        public IModbusMaster CreateMaster(Socket client)
+        {
+            var adapter = new SocketAdapter(client);
+
+            var transport = new ModbusRtuTransport(adapter, this, Logger);
+
+            return new ModbusSerialMaster(transport);
+        }
+
         public IModbusFunctionService GetFunctionService(byte functionCode)
         {
             return _functionServices.GetValueOrDefault(functionCode);

--- a/Samples/Program.cs
+++ b/Samples/Program.cs
@@ -19,7 +19,7 @@ namespace Samples
     /// </summary>
     public class Driver
     {
-        private const string PrimarySerialPortName = "COM12";
+        private const string PrimarySerialPortName = "COM4";
         private const string SecondarySerialPortName = "COM2";
 
         private static async Task<int> Main(string[] args)
@@ -30,6 +30,10 @@ namespace Samples
 
             try
             {
+                ModbusSocketSerialMasterReadRegisters();
+                ModbusSocketSerialMasterWriteRegisters();
+                ModbusSocketSerialMasterReadRegisters();
+                await Task.Run(() => { });
                 //ModbusTcpMasterReadInputs();
                 //SimplePerfTest();
                 //ModbusSerialRtuMasterWriteRegisters();
@@ -42,8 +46,9 @@ namespace Samples
                 //StartModbusUdpSlave();
                 //StartModbusAsciiSlave();
                 //await StartModbusSerialRtuSlaveNetwork(cts.Token);
-                await StartModbusSerialRtuSlaveWithCustomMessage(cts.Token);
+                //await StartModbusSerialRtuSlaveWithCustomMessage(cts.Token);
             }
+
             catch (Exception e)
             {
                 Console.WriteLine(e.Message);
@@ -80,7 +85,60 @@ namespace Samples
                 master.WriteMultipleRegisters(slaveId, startAddress, registers);
             }
         }
+        /// <summary>
+        /// Simple write to socket connector sending RTU messages
+        /// </summary>
+        public static void ModbusSocketSerialMasterWriteRegisters()
+        {
 
+
+            using (var sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+
+                // configure socket
+                var serverIP = IPAddress.Parse("192.168.2.100");
+                var serverFullAddr = new IPEndPoint(serverIP, 9000);
+                sock.Connect(serverFullAddr);
+
+                var factory = new ModbusFactory();
+                IModbusMaster master = factory.CreateMaster(sock);
+
+                byte slaveId = 1;
+                ushort startAddress = 100;
+                ushort[] registers = new ushort[] { 10, 20, 30 };
+
+                // write three registers
+                master.WriteMultipleRegisters(slaveId, startAddress, registers);
+            }
+        }
+        /// <summary>
+        /// Simple Read registers using socket and expecting RTU fromatted response messages.
+        /// </summary>
+        public static void ModbusSocketSerialMasterReadRegisters()
+        {
+
+
+            using (var sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+
+                // configure socket
+                var serverIP = IPAddress.Parse("192.168.2.100");
+                var serverFullAddr = new IPEndPoint(serverIP, 9000);
+                sock.Connect(serverFullAddr);
+
+                var factory = new ModbusFactory();
+                IModbusMaster master = factory.CreateMaster(sock);
+
+                byte slaveId = 1;
+                ushort startAddress = 100;
+                ushort[] registers = master.ReadHoldingRegisters(slaveId, startAddress, 3);
+                for (int i = 0; i < 3; i++)
+                {
+                    Console.WriteLine($"Input {(startAddress + i)}={registers[i]}");
+                }
+
+            }
+        }
         /// <summary>
         ///     Simple Modbus serial ASCII master read holding registers example.
         /// </summary>


### PR DESCRIPTION
I have added a simple adapter to the IO to  be able to make a Socket based connection to a Modbus RTU device.

**Background**
As more IOT is develop the need for RS485 connections to Modbus devices is growing. modern Modbus master devices do not have Serial ports anymore (we use a Raspberry PI 4 for example). Furthermore not all Modbus slave devices are close to the central Modbus master device. One solution for this is to use a RS458 to Ethernet converter as a LAN network is easy to set up.
The converter takes a socket connection to receive messages and forward these over the com as Rx messages. 

**changes**
- Created SocketAdapter.
- Added overload to ModbusFactory that takes a Socket and creates a RTU master with a Socket as transport.

Regards Michiel van Buuren.