### PR TITLE
Added sleep between retries to conform with the configured delay.

### DIFF
--- a/NModbus/IO/ModbusTransport.cs
+++ b/NModbus/IO/ModbusTransport.cs
@@ -176,18 +176,15 @@ namespace NModbus.IO
                     }
 
                     Logger.Warning($"Received SLAVE_DEVICE_BUSY exception response, waiting {_waitToRetryMilliseconds} milliseconds and resubmitting request.");
+
                     Sleep(WaitToRetryMilliseconds);
                 }
                 catch (Exception e)
                 {
-                    if (e is SocketException || e.InnerException is SocketException)
-                    {
-                        throw;
-                    }
-                    else if (e is FormatException ||
-                             e is NotImplementedException ||
-                             e is TimeoutException ||
-                             e is IOException)
+                    if (e is FormatException ||
+                        e is NotImplementedException ||
+                        e is TimeoutException ||
+                        e is IOException)
                     {
                         Logger.Error($"{e.GetType().Name}, {(_retries - attempt + 1)} retries remaining - {e}");
 
@@ -195,6 +192,8 @@ namespace NModbus.IO
                         {
                             throw;
                         }
+
+                        Sleep(WaitToRetryMilliseconds);
                     }
                     else
                     {

--- a/NModbus/IO/ModbusTransport.cs
+++ b/NModbus/IO/ModbusTransport.cs
@@ -181,7 +181,11 @@ namespace NModbus.IO
                 }
                 catch (Exception e)
                 {
-                    if (e is FormatException ||
+                    if (e is SocketException || e.InnerException is SocketException)
+                    {
+                        throw;
+                    }
+                    else if (e is FormatException ||
                         e is NotImplementedException ||
                         e is TimeoutException ||
                         e is IOException)


### PR DESCRIPTION
# Description

We've changed the handling of the exceptions thrown by the transport to conform with the configured delay between retries. This way, we prevent that protocol errors and intermitent communication problems disconnect the device.

Fixes #93 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
