### PR TITLE
Fix to support 32bit register size (enron)

### DIFF
--- a/NModbus/Device/ModbusMaster.cs
+++ b/NModbus/Device/ModbusMaster.cs
@@ -117,6 +117,26 @@ namespace NModbus.Device
             return PerformReadRegisters(request);
         }
 
+				/// <summary>
+				///    Reads contiguous block of holding registers.
+				/// </summary>
+				/// <param name="slaveAddress">Address of device to read values from.</param>
+				/// <param name="startAddress">Address to begin reading.</param>
+				/// <param name="numberOfPoints">Number of holding registers to read.</param>
+				/// <returns>Holding registers status.</returns>
+				public uint[] ReadHoldingRegisters32(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+        {
+            ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 62);
+
+            var request = new ReadHoldingInputRegisters32Request(
+                ModbusFunctionCodes.ReadHoldingRegisters,
+                slaveAddress,
+                startAddress,
+                numberOfPoints);
+
+            return PerformReadRegisters(request);
+        }
+
         /// <summary>
         ///    Asynchronously reads contiguous block of holding registers.
         /// </summary>
@@ -129,6 +149,26 @@ namespace NModbus.Device
             ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 125);
 
             var request = new ReadHoldingInputRegistersRequest(
+                ModbusFunctionCodes.ReadHoldingRegisters,
+                slaveAddress,
+                startAddress,
+                numberOfPoints);
+
+            return PerformReadRegistersAsync(request);
+        }
+
+        /// <summary>
+        ///    Asynchronously reads contiguous block of holding registers.
+        /// </summary>
+        /// <param name="slaveAddress">Address of device to read values from.</param>
+        /// <param name="startAddress">Address to begin reading.</param>
+        /// <param name="numberOfPoints">Number of holding registers to read.</param>
+        /// <returns>A task that represents the asynchronous read operation.</returns>
+        public Task<uint[]> ReadHoldingRegisters32Async(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+        {
+            ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 125);
+
+            var request = new ReadHoldingInputRegisters32Request(
                 ModbusFunctionCodes.ReadHoldingRegisters,
                 slaveAddress,
                 startAddress,
@@ -157,6 +197,26 @@ namespace NModbus.Device
             return PerformReadRegisters(request);
         }
 
+		    /// <summary>
+				///    Reads contiguous block of input registers with 32 bit register size.
+		    /// </summary>
+		    /// <param name="slaveAddress">Address of device to read values from.</param>
+		    /// <param name="startAddress">Address to begin reading.</param>
+		    /// <param name="numberOfPoints">Number of holding registers to read.</param>
+		    /// <returns>Input registers status.</returns>
+				public uint[] ReadInputRegisters32(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+        {
+            ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 62);
+
+            var request = new ReadHoldingInputRegisters32Request(
+                ModbusFunctionCodes.ReadInputRegisters,
+                slaveAddress,
+                startAddress,
+                numberOfPoints);
+
+            return PerformReadRegisters(request);
+        }
+
         /// <summary>
         ///    Asynchronously reads contiguous block of input registers.
         /// </summary>
@@ -169,6 +229,26 @@ namespace NModbus.Device
             ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 125);
 
             var request = new ReadHoldingInputRegistersRequest(
+                ModbusFunctionCodes.ReadInputRegisters,
+                slaveAddress,
+                startAddress,
+                numberOfPoints);
+
+            return PerformReadRegistersAsync(request);
+        }
+
+		    /// <summary>
+		    ///    Asynchronously reads contiguous block of input registers with 32 bit register size.
+		    /// </summary>
+		    /// <param name="slaveAddress">Address of device to read values from.</param>
+		    /// <param name="startAddress">Address to begin reading.</param>
+		    /// <param name="numberOfPoints">Number of holding registers to read.</param>
+		    /// <returns>A task that represents the asynchronous read operation.</returns>
+		    public Task<uint[]> ReadInputRegisters32Async(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+        {
+            ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 125);
+
+            var request = new ReadHoldingInputRegisters32Request(
                 ModbusFunctionCodes.ReadInputRegisters,
                 slaveAddress,
                 startAddress,
@@ -453,12 +533,35 @@ namespace NModbus.Device
             return response.Data.Take(request.NumberOfPoints).ToArray();
         }
 
+        private uint[] PerformReadRegisters(ReadHoldingInputRegisters32Request request)
+        {
+            ReadHoldingInputRegistersResponse response =
+                Transport.UnicastMessage<ReadHoldingInputRegistersResponse>(request);
+
+						uint[] registers = new uint[request.NumberOfPoints];
+
+            if (response.Data is IModbusMessageDataCollection data)
+			      {
+							for (int i = 0; i < response.Data.ByteCount; i += 4)
+							{
+								registers[i / 4] = (uint) (data.NetworkBytes[i + 0] << 24 | data.NetworkBytes[i + 1] << 16 | data.NetworkBytes[i + 2] << 8 | data.NetworkBytes[i + 3]);
+							}
+			      }
+
+						return registers.Take(request.NumberOfPoints).ToArray();
+				}
+
         private Task<ushort[]> PerformReadRegistersAsync(ReadHoldingInputRegistersRequest request)
         {
             return Task.Factory.StartNew(() => PerformReadRegisters(request));
-        }
+    }
 
-        private ushort[] PerformReadRegisters(ReadWriteMultipleRegistersRequest request)
+				private Task<uint[]> PerformReadRegistersAsync(ReadHoldingInputRegisters32Request request)
+				{
+					return Task.Factory.StartNew(() => PerformReadRegisters(request));
+				}
+
+    private ushort[] PerformReadRegisters(ReadWriteMultipleRegistersRequest request)
         {
             ReadHoldingInputRegistersResponse response =
                 Transport.UnicastMessage<ReadHoldingInputRegistersResponse>(request);

--- a/NModbus/Device/ModbusMaster.cs
+++ b/NModbus/Device/ModbusMaster.cs
@@ -118,26 +118,6 @@ namespace NModbus.Device
 		}
 
 		/// <summary>
-		///    Reads contiguous block of holding registers.
-		/// </summary>
-		/// <param name="slaveAddress">Address of device to read values from.</param>
-		/// <param name="startAddress">Address to begin reading.</param>
-		/// <param name="numberOfPoints">Number of holding registers to read.</param>
-		/// <returns>Holding registers status.</returns>
-		public uint[] ReadHoldingRegisters32(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
-		{
-			ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 62);
-
-			var request = new ReadHoldingInputRegisters32Request(
-					ModbusFunctionCodes.ReadHoldingRegisters,
-					slaveAddress,
-					startAddress,
-					numberOfPoints);
-
-			return PerformReadRegisters(request);
-		}
-
-		/// <summary>
 		///    Asynchronously reads contiguous block of holding registers.
 		/// </summary>
 		/// <param name="slaveAddress">Address of device to read values from.</param>
@@ -149,26 +129,6 @@ namespace NModbus.Device
 			ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 125);
 
 			var request = new ReadHoldingInputRegistersRequest(
-					ModbusFunctionCodes.ReadHoldingRegisters,
-					slaveAddress,
-					startAddress,
-					numberOfPoints);
-
-			return PerformReadRegistersAsync(request);
-		}
-
-		/// <summary>
-		///    Asynchronously reads contiguous block of holding registers.
-		/// </summary>
-		/// <param name="slaveAddress">Address of device to read values from.</param>
-		/// <param name="startAddress">Address to begin reading.</param>
-		/// <param name="numberOfPoints">Number of holding registers to read.</param>
-		/// <returns>A task that represents the asynchronous read operation.</returns>
-		public Task<uint[]> ReadHoldingRegisters32Async(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
-		{
-			ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 125);
-
-			var request = new ReadHoldingInputRegisters32Request(
 					ModbusFunctionCodes.ReadHoldingRegisters,
 					slaveAddress,
 					startAddress,
@@ -198,26 +158,6 @@ namespace NModbus.Device
 		}
 
 		/// <summary>
-		///    Reads contiguous block of input registers with 32 bit register size.
-		/// </summary>
-		/// <param name="slaveAddress">Address of device to read values from.</param>
-		/// <param name="startAddress">Address to begin reading.</param>
-		/// <param name="numberOfPoints">Number of holding registers to read.</param>
-		/// <returns>Input registers status.</returns>
-		public uint[] ReadInputRegisters32(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
-		{
-			ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 62);
-
-			var request = new ReadHoldingInputRegisters32Request(
-					ModbusFunctionCodes.ReadInputRegisters,
-					slaveAddress,
-					startAddress,
-					numberOfPoints);
-
-			return PerformReadRegisters(request);
-		}
-
-		/// <summary>
 		///    Asynchronously reads contiguous block of input registers.
 		/// </summary>
 		/// <param name="slaveAddress">Address of device to read values from.</param>
@@ -229,26 +169,6 @@ namespace NModbus.Device
 			ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 125);
 
 			var request = new ReadHoldingInputRegistersRequest(
-					ModbusFunctionCodes.ReadInputRegisters,
-					slaveAddress,
-					startAddress,
-					numberOfPoints);
-
-			return PerformReadRegistersAsync(request);
-		}
-
-		/// <summary>
-		///    Asynchronously reads contiguous block of input registers with 32 bit register size.
-		/// </summary>
-		/// <param name="slaveAddress">Address of device to read values from.</param>
-		/// <param name="startAddress">Address to begin reading.</param>
-		/// <param name="numberOfPoints">Number of holding registers to read.</param>
-		/// <returns>A task that represents the asynchronous read operation.</returns>
-		public Task<uint[]> ReadInputRegisters32Async(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
-		{
-			ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 125);
-
-			var request = new ReadHoldingInputRegisters32Request(
 					ModbusFunctionCodes.ReadInputRegisters,
 					slaveAddress,
 					startAddress,
@@ -533,30 +453,7 @@ namespace NModbus.Device
 			return response.Data.Take(request.NumberOfPoints).ToArray();
 		}
 
-		private uint[] PerformReadRegisters(ReadHoldingInputRegisters32Request request)
-		{
-			ReadHoldingInputRegistersResponse response =
-					Transport.UnicastMessage<ReadHoldingInputRegistersResponse>(request);
-
-			uint[] registers = new uint[request.NumberOfPoints];
-
-			if (response.Data is IModbusMessageDataCollection data)
-			{
-				for (int i = 0; i < response.Data.ByteCount; i += 4)
-				{
-					registers[i / 4] = (uint)(data.NetworkBytes[i + 0] << 24 | data.NetworkBytes[i + 1] << 16 | data.NetworkBytes[i + 2] << 8 | data.NetworkBytes[i + 3]);
-				}
-			}
-
-			return registers.Take(request.NumberOfPoints).ToArray();
-		}
-
 		private Task<ushort[]> PerformReadRegistersAsync(ReadHoldingInputRegistersRequest request)
-		{
-			return Task.Factory.StartNew(() => PerformReadRegisters(request));
-		}
-
-		private Task<uint[]> PerformReadRegistersAsync(ReadHoldingInputRegisters32Request request)
 		{
 			return Task.Factory.StartNew(() => PerformReadRegisters(request));
 		}

--- a/NModbus/Device/ModbusMaster.cs
+++ b/NModbus/Device/ModbusMaster.cs
@@ -7,577 +7,577 @@ using NModbus.Message;
 
 namespace NModbus.Device
 {
-    /// <summary>
-    ///     Modbus master device.
-    /// </summary>
-    internal abstract class ModbusMaster : ModbusDevice, IModbusMaster
-    {
-        internal ModbusMaster(IModbusTransport transport)
-            : base(transport)
-        {
-        }
-
-        /// <summary>
-        ///    Reads from 1 to 2000 contiguous coils status.
-        /// </summary>
-        /// <param name="slaveAddress">Address of device to read values from.</param>
-        /// <param name="startAddress">Address to begin reading.</param>
-        /// <param name="numberOfPoints">Number of coils to read.</param>
-        /// <returns>Coils status.</returns>
-        public bool[] ReadCoils(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
-        {
-            ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 2000);
-
-            var request = new ReadCoilsInputsRequest(
-                ModbusFunctionCodes.ReadCoils,
-                slaveAddress,
-                startAddress,
-                numberOfPoints);
-
-            return PerformReadDiscretes(request);
-        }
-
-        /// <summary>
-        ///    Asynchronously reads from 1 to 2000 contiguous coils status.
-        /// </summary>
-        /// <param name="slaveAddress">Address of device to read values from.</param>
-        /// <param name="startAddress">Address to begin reading.</param>
-        /// <param name="numberOfPoints">Number of coils to read.</param>
-        /// <returns>A task that represents the asynchronous read operation.</returns>
-        public Task<bool[]> ReadCoilsAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
-        {
-            ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 2000);
-
-            var request = new ReadCoilsInputsRequest(
-                ModbusFunctionCodes.ReadCoils,
-                slaveAddress,
-                startAddress,
-                numberOfPoints);
-
-            return PerformReadDiscretesAsync(request);
-        }
-
-        /// <summary>
-        ///    Reads from 1 to 2000 contiguous discrete input status.
-        /// </summary>
-        /// <param name="slaveAddress">Address of device to read values from.</param>
-        /// <param name="startAddress">Address to begin reading.</param>
-        /// <param name="numberOfPoints">Number of discrete inputs to read.</param>
-        /// <returns>Discrete inputs status.</returns>
-        public bool[] ReadInputs(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
-        {
-            ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 2000);
-
-            var request = new ReadCoilsInputsRequest(
-                ModbusFunctionCodes.ReadInputs,
-                slaveAddress,
-                startAddress,
-                numberOfPoints);
-
-            return PerformReadDiscretes(request);
-        }
-
-        /// <summary>
-        ///    Asynchronously reads from 1 to 2000 contiguous discrete input status.
-        /// </summary>
-        /// <param name="slaveAddress">Address of device to read values from.</param>
-        /// <param name="startAddress">Address to begin reading.</param>
-        /// <param name="numberOfPoints">Number of discrete inputs to read.</param>
-        /// <returns>A task that represents the asynchronous read operation.</returns>
-        public Task<bool[]> ReadInputsAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
-        {
-            ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 2000);
-
-            var request = new ReadCoilsInputsRequest(
-                ModbusFunctionCodes.ReadInputs,
-                slaveAddress,
-                startAddress,
-                numberOfPoints);
-
-            return PerformReadDiscretesAsync(request);
-        }
-
-        /// <summary>
-        ///    Reads contiguous block of holding registers.
-        /// </summary>
-        /// <param name="slaveAddress">Address of device to read values from.</param>
-        /// <param name="startAddress">Address to begin reading.</param>
-        /// <param name="numberOfPoints">Number of holding registers to read.</param>
-        /// <returns>Holding registers status.</returns>
-        public ushort[] ReadHoldingRegisters(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
-        {
-            ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 125);
-
-            var request = new ReadHoldingInputRegistersRequest(
-                ModbusFunctionCodes.ReadHoldingRegisters,
-                slaveAddress,
-                startAddress,
-                numberOfPoints);
-
-            return PerformReadRegisters(request);
-        }
-
-				/// <summary>
-				///    Reads contiguous block of holding registers.
-				/// </summary>
-				/// <param name="slaveAddress">Address of device to read values from.</param>
-				/// <param name="startAddress">Address to begin reading.</param>
-				/// <param name="numberOfPoints">Number of holding registers to read.</param>
-				/// <returns>Holding registers status.</returns>
-				public uint[] ReadHoldingRegisters32(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
-        {
-            ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 62);
-
-            var request = new ReadHoldingInputRegisters32Request(
-                ModbusFunctionCodes.ReadHoldingRegisters,
-                slaveAddress,
-                startAddress,
-                numberOfPoints);
-
-            return PerformReadRegisters(request);
-        }
-
-        /// <summary>
-        ///    Asynchronously reads contiguous block of holding registers.
-        /// </summary>
-        /// <param name="slaveAddress">Address of device to read values from.</param>
-        /// <param name="startAddress">Address to begin reading.</param>
-        /// <param name="numberOfPoints">Number of holding registers to read.</param>
-        /// <returns>A task that represents the asynchronous read operation.</returns>
-        public Task<ushort[]> ReadHoldingRegistersAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
-        {
-            ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 125);
-
-            var request = new ReadHoldingInputRegistersRequest(
-                ModbusFunctionCodes.ReadHoldingRegisters,
-                slaveAddress,
-                startAddress,
-                numberOfPoints);
-
-            return PerformReadRegistersAsync(request);
-        }
-
-        /// <summary>
-        ///    Asynchronously reads contiguous block of holding registers.
-        /// </summary>
-        /// <param name="slaveAddress">Address of device to read values from.</param>
-        /// <param name="startAddress">Address to begin reading.</param>
-        /// <param name="numberOfPoints">Number of holding registers to read.</param>
-        /// <returns>A task that represents the asynchronous read operation.</returns>
-        public Task<uint[]> ReadHoldingRegisters32Async(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
-        {
-            ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 125);
-
-            var request = new ReadHoldingInputRegisters32Request(
-                ModbusFunctionCodes.ReadHoldingRegisters,
-                slaveAddress,
-                startAddress,
-                numberOfPoints);
-
-            return PerformReadRegistersAsync(request);
-        }
-
-        /// <summary>
-        ///    Reads contiguous block of input registers.
-        /// </summary>
-        /// <param name="slaveAddress">Address of device to read values from.</param>
-        /// <param name="startAddress">Address to begin reading.</param>
-        /// <param name="numberOfPoints">Number of holding registers to read.</param>
-        /// <returns>Input registers status.</returns>
-        public ushort[] ReadInputRegisters(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
-        {
-            ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 125);
-
-            var request = new ReadHoldingInputRegistersRequest(
-                ModbusFunctionCodes.ReadInputRegisters,
-                slaveAddress,
-                startAddress,
-                numberOfPoints);
-
-            return PerformReadRegisters(request);
-        }
-
-		    /// <summary>
-				///    Reads contiguous block of input registers with 32 bit register size.
-		    /// </summary>
-		    /// <param name="slaveAddress">Address of device to read values from.</param>
-		    /// <param name="startAddress">Address to begin reading.</param>
-		    /// <param name="numberOfPoints">Number of holding registers to read.</param>
-		    /// <returns>Input registers status.</returns>
-				public uint[] ReadInputRegisters32(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
-        {
-            ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 62);
-
-            var request = new ReadHoldingInputRegisters32Request(
-                ModbusFunctionCodes.ReadInputRegisters,
-                slaveAddress,
-                startAddress,
-                numberOfPoints);
-
-            return PerformReadRegisters(request);
-        }
-
-        /// <summary>
-        ///    Asynchronously reads contiguous block of input registers.
-        /// </summary>
-        /// <param name="slaveAddress">Address of device to read values from.</param>
-        /// <param name="startAddress">Address to begin reading.</param>
-        /// <param name="numberOfPoints">Number of holding registers to read.</param>
-        /// <returns>A task that represents the asynchronous read operation.</returns>
-        public Task<ushort[]> ReadInputRegistersAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
-        {
-            ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 125);
-
-            var request = new ReadHoldingInputRegistersRequest(
-                ModbusFunctionCodes.ReadInputRegisters,
-                slaveAddress,
-                startAddress,
-                numberOfPoints);
-
-            return PerformReadRegistersAsync(request);
-        }
-
-		    /// <summary>
-		    ///    Asynchronously reads contiguous block of input registers with 32 bit register size.
-		    /// </summary>
-		    /// <param name="slaveAddress">Address of device to read values from.</param>
-		    /// <param name="startAddress">Address to begin reading.</param>
-		    /// <param name="numberOfPoints">Number of holding registers to read.</param>
-		    /// <returns>A task that represents the asynchronous read operation.</returns>
-		    public Task<uint[]> ReadInputRegisters32Async(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
-        {
-            ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 125);
-
-            var request = new ReadHoldingInputRegisters32Request(
-                ModbusFunctionCodes.ReadInputRegisters,
-                slaveAddress,
-                startAddress,
-                numberOfPoints);
-
-            return PerformReadRegistersAsync(request);
-        }
-
-        /// <summary>
-        ///    Writes a single coil value.
-        /// </summary>
-        /// <param name="slaveAddress">Address of the device to write to.</param>
-        /// <param name="coilAddress">Address to write value to.</param>
-        /// <param name="value">Value to write.</param>
-        public void WriteSingleCoil(byte slaveAddress, ushort coilAddress, bool value)
-        {
-            var request = new WriteSingleCoilRequestResponse(slaveAddress, coilAddress, value);
-            Transport.UnicastMessage<WriteSingleCoilRequestResponse>(request);
-        }
-
-        /// <summary>
-        ///    Asynchronously writes a single coil value.
-        /// </summary>
-        /// <param name="slaveAddress">Address of the device to write to.</param>
-        /// <param name="coilAddress">Address to write value to.</param>
-        /// <param name="value">Value to write.</param>
-        /// <returns>A task that represents the asynchronous write operation.</returns>
-        public Task WriteSingleCoilAsync(byte slaveAddress, ushort coilAddress, bool value)
-        {
-            var request = new WriteSingleCoilRequestResponse(slaveAddress, coilAddress, value);
-            return PerformWriteRequestAsync<WriteSingleCoilRequestResponse>(request);
-        }
-
-        /// <summary>
-        ///    Writes a single holding register.
-        /// </summary>
-        /// <param name="slaveAddress">Address of the device to write to.</param>
-        /// <param name="registerAddress">Address to write.</param>
-        /// <param name="value">Value to write.</param>
-        public void WriteSingleRegister(byte slaveAddress, ushort registerAddress, ushort value)
-        {
-            var request = new WriteSingleRegisterRequestResponse(
-                slaveAddress,
-                registerAddress,
-                value);
-
-            Transport.UnicastMessage<WriteSingleRegisterRequestResponse>(request);
-        }
-
-        /// <summary>
-        ///    Asynchronously writes a single holding register.
-        /// </summary>
-        /// <param name="slaveAddress">Address of the device to write to.</param>
-        /// <param name="registerAddress">Address to write.</param>
-        /// <param name="value">Value to write.</param>
-        /// <returns>A task that represents the asynchronous write operation.</returns>
-        public Task WriteSingleRegisterAsync(byte slaveAddress, ushort registerAddress, ushort value)
-        {
-            var request = new WriteSingleRegisterRequestResponse(
-                slaveAddress,
-                registerAddress,
-                value);
-
-            return PerformWriteRequestAsync<WriteSingleRegisterRequestResponse>(request);
-        }
-
-        /// <summary>
-        ///     Write a block of 1 to 123 contiguous 16 bit holding registers.
-        /// </summary>
-        /// <param name="slaveAddress">Address of the device to write to.</param>
-        /// <param name="startAddress">Address to begin writing values.</param>
-        /// <param name="data">Values to write.</param>
-        public void WriteMultipleRegisters(byte slaveAddress, ushort startAddress, ushort[] data)
-        {
-            ValidateData("data", data, 123);
-
-            var request = new WriteMultipleRegistersRequest(
-                slaveAddress,
-                startAddress,
-                new RegisterCollection(data));
-
-            Transport.UnicastMessage<WriteMultipleRegistersResponse>(request);
-        }
-
-        /// <summary>
-        ///    Asynchronously writes a block of 1 to 123 contiguous registers.
-        /// </summary>
-        /// <param name="slaveAddress">Address of the device to write to.</param>
-        /// <param name="startAddress">Address to begin writing values.</param>
-        /// <param name="data">Values to write.</param>
-        /// <returns>A task that represents the asynchronous write operation.</returns>
-        public Task WriteMultipleRegistersAsync(byte slaveAddress, ushort startAddress, ushort[] data)
-        {
-            ValidateData("data", data, 123);
-
-            var request = new WriteMultipleRegistersRequest(
-                slaveAddress,
-                startAddress,
-                new RegisterCollection(data));
-
-            return PerformWriteRequestAsync<WriteMultipleRegistersResponse>(request);
-        }
-
-        /// <summary>
-        ///    Writes a sequence of coils.
-        /// </summary>
-        /// <param name="slaveAddress">Address of the device to write to.</param>
-        /// <param name="startAddress">Address to begin writing values.</param>
-        /// <param name="data">Values to write.</param>
-        public void WriteMultipleCoils(byte slaveAddress, ushort startAddress, bool[] data)
-        {
-            ValidateData("data", data, 1968);
-
-            var request = new WriteMultipleCoilsRequest(
-                slaveAddress,
-                startAddress,
-                new DiscreteCollection(data));
-
-            Transport.UnicastMessage<WriteMultipleCoilsResponse>(request);
-        }
-
-        /// <summary>
-        ///    Asynchronously writes a sequence of coils.
-        /// </summary>
-        /// <param name="slaveAddress">Address of the device to write to.</param>
-        /// <param name="startAddress">Address to begin writing values.</param>
-        /// <param name="data">Values to write.</param>
-        /// <returns>A task that represents the asynchronous write operation.</returns>
-        public Task WriteMultipleCoilsAsync(byte slaveAddress, ushort startAddress, bool[] data)
-        {
-            ValidateData("data", data, 1968);
-
-            var request = new WriteMultipleCoilsRequest(
-                slaveAddress,
-                startAddress,
-                new DiscreteCollection(data));
-
-            return PerformWriteRequestAsync<WriteMultipleCoilsResponse>(request);
-        }
-
-        /// <summary>
-        ///    Performs a combination of one read operation and one write operation in a single Modbus transaction.
-        ///    The write operation is performed before the read.
-        /// </summary>
-        /// <param name="slaveAddress">Address of device to read values from.</param>
-        /// <param name="startReadAddress">Address to begin reading (Holding registers are addressed starting at 0).</param>
-        /// <param name="numberOfPointsToRead">Number of registers to read.</param>
-        /// <param name="startWriteAddress">Address to begin writing (Holding registers are addressed starting at 0).</param>
-        /// <param name="writeData">Register values to write.</param>
-        public ushort[] ReadWriteMultipleRegisters(
-            byte slaveAddress,
-            ushort startReadAddress,
-            ushort numberOfPointsToRead,
-            ushort startWriteAddress,
-            ushort[] writeData)
-        {
-            ValidateNumberOfPoints("numberOfPointsToRead", numberOfPointsToRead, 125);
-            ValidateData("writeData", writeData, 121);
-
-            var request = new ReadWriteMultipleRegistersRequest(
-                slaveAddress,
-                startReadAddress,
-                numberOfPointsToRead,
-                startWriteAddress,
-                new RegisterCollection(writeData));
-
-            return PerformReadRegisters(request);
-        }
-
-        /// <summary>
-        ///    Asynchronously performs a combination of one read operation and one write operation in a single Modbus transaction.
-        ///    The write operation is performed before the read.
-        /// </summary>
-        /// <param name="slaveAddress">Address of device to read values from.</param>
-        /// <param name="startReadAddress">Address to begin reading (Holding registers are addressed starting at 0).</param>
-        /// <param name="numberOfPointsToRead">Number of registers to read.</param>
-        /// <param name="startWriteAddress">Address to begin writing (Holding registers are addressed starting at 0).</param>
-        /// <param name="writeData">Register values to write.</param>
-        /// <returns>A task that represents the asynchronous operation.</returns>
-        public Task<ushort[]> ReadWriteMultipleRegistersAsync(
-            byte slaveAddress,
-            ushort startReadAddress,
-            ushort numberOfPointsToRead,
-            ushort startWriteAddress,
-            ushort[] writeData)
-        {
-            ValidateNumberOfPoints("numberOfPointsToRead", numberOfPointsToRead, 125);
-            ValidateData("writeData", writeData, 121);
-
-            var request = new ReadWriteMultipleRegistersRequest(
-                slaveAddress,
-                startReadAddress,
-                numberOfPointsToRead,
-                startWriteAddress,
-                new RegisterCollection(writeData));
-
-            return PerformReadRegistersAsync(request);
-        }
-
-        /// <summary>
-        /// Write a file record to the device.
-        /// </summary>
-        /// <param name="slaveAdress">Address of device to write values to</param>
-        /// <param name="fileNumber">The Extended Memory file number</param>
-        /// <param name="startingAddress">The starting register address within the file</param>
-        /// <param name="data">The data to be written</param>
-        public void WriteFileRecord(byte slaveAdress, ushort fileNumber, ushort startingAddress, byte[] data)
-        {
-            ValidateMaxData("data", data, 244);
-            var request = new WriteFileRecordRequest(slaveAdress, new FileRecordCollection(
-                fileNumber, startingAddress, data));
-
-            Transport.UnicastMessage<WriteFileRecordResponse>(request);
-        }
-
-        /// <summary>
-        ///    Executes the custom message.
-        /// </summary>
-        /// <typeparam name="TResponse">The type of the response.</typeparam>
-        /// <param name="request">The request.</param>
-        [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter")]
-        [SuppressMessage("Microsoft.Usage", "CA2223:MembersShouldDifferByMoreThanReturnType")]
-        public TResponse ExecuteCustomMessage<TResponse>(IModbusMessage request)
-            where TResponse : IModbusMessage, new()
-        {
-            return Transport.UnicastMessage<TResponse>(request);
-        }
-
-        private static void ValidateData<T>(string argumentName, T[] data, int maxDataLength)
-        {
-            if (data == null)
-            {
-                throw new ArgumentNullException(nameof(data));
-            }
-
-            if (data.Length == 0 || data.Length > maxDataLength)
-            {
-                string msg = $"The length of argument {argumentName} must be between 1 and {maxDataLength} inclusive.";
-                throw new ArgumentException(msg);
-            }
-        }
-
-        private static void ValidateMaxData<T>(string argumentName, T[] data, int maxDataLength)
-        {
-            if (data == null)
-            {
-                throw new ArgumentNullException(nameof(data));
-            }
-
-            if (data.Length > maxDataLength)
-            {
-                string msg = $"The length of argument {argumentName} must not be greater than {maxDataLength}.";
-                throw new ArgumentException(msg);
-            }
-        }
-
-        private static void ValidateNumberOfPoints(string argumentName, ushort numberOfPoints, ushort maxNumberOfPoints)
-        {
-            if (numberOfPoints < 1 || numberOfPoints > maxNumberOfPoints)
-            {
-                string msg = $"Argument {argumentName} must be between 1 and {maxNumberOfPoints} inclusive.";
-                throw new ArgumentException(msg);
-            }
-        }
-
-        private bool[] PerformReadDiscretes(ReadCoilsInputsRequest request)
-        {
-            ReadCoilsInputsResponse response = Transport.UnicastMessage<ReadCoilsInputsResponse>(request);
-            return response.Data.Take(request.NumberOfPoints).ToArray();
-        }
-
-        private Task<bool[]> PerformReadDiscretesAsync(ReadCoilsInputsRequest request)
-        {
-            return Task.Factory.StartNew(() => PerformReadDiscretes(request));
-        }
-
-        private ushort[] PerformReadRegisters(ReadHoldingInputRegistersRequest request)
-        {
-            ReadHoldingInputRegistersResponse response =
-                Transport.UnicastMessage<ReadHoldingInputRegistersResponse>(request);
-
-            return response.Data.Take(request.NumberOfPoints).ToArray();
-        }
-
-        private uint[] PerformReadRegisters(ReadHoldingInputRegisters32Request request)
-        {
-            ReadHoldingInputRegistersResponse response =
-                Transport.UnicastMessage<ReadHoldingInputRegistersResponse>(request);
-
-						uint[] registers = new uint[request.NumberOfPoints];
-
-            if (response.Data is IModbusMessageDataCollection data)
-			      {
-							for (int i = 0; i < response.Data.ByteCount; i += 4)
-							{
-								registers[i / 4] = (uint) (data.NetworkBytes[i + 0] << 24 | data.NetworkBytes[i + 1] << 16 | data.NetworkBytes[i + 2] << 8 | data.NetworkBytes[i + 3]);
-							}
-			      }
-
-						return registers.Take(request.NumberOfPoints).ToArray();
-				}
-
-        private Task<ushort[]> PerformReadRegistersAsync(ReadHoldingInputRegistersRequest request)
-        {
-            return Task.Factory.StartNew(() => PerformReadRegisters(request));
-    }
-
-				private Task<uint[]> PerformReadRegistersAsync(ReadHoldingInputRegisters32Request request)
+	/// <summary>
+	///     Modbus master device.
+	/// </summary>
+	internal abstract class ModbusMaster : ModbusDevice, IModbusMaster
+	{
+		internal ModbusMaster(IModbusTransport transport)
+				: base(transport)
+		{
+		}
+
+		/// <summary>
+		///    Reads from 1 to 2000 contiguous coils status.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of coils to read.</param>
+		/// <returns>Coils status.</returns>
+		public bool[] ReadCoils(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+		{
+			ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 2000);
+
+			var request = new ReadCoilsInputsRequest(
+					ModbusFunctionCodes.ReadCoils,
+					slaveAddress,
+					startAddress,
+					numberOfPoints);
+
+			return PerformReadDiscretes(request);
+		}
+
+		/// <summary>
+		///    Asynchronously reads from 1 to 2000 contiguous coils status.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of coils to read.</param>
+		/// <returns>A task that represents the asynchronous read operation.</returns>
+		public Task<bool[]> ReadCoilsAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+		{
+			ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 2000);
+
+			var request = new ReadCoilsInputsRequest(
+					ModbusFunctionCodes.ReadCoils,
+					slaveAddress,
+					startAddress,
+					numberOfPoints);
+
+			return PerformReadDiscretesAsync(request);
+		}
+
+		/// <summary>
+		///    Reads from 1 to 2000 contiguous discrete input status.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of discrete inputs to read.</param>
+		/// <returns>Discrete inputs status.</returns>
+		public bool[] ReadInputs(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+		{
+			ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 2000);
+
+			var request = new ReadCoilsInputsRequest(
+					ModbusFunctionCodes.ReadInputs,
+					slaveAddress,
+					startAddress,
+					numberOfPoints);
+
+			return PerformReadDiscretes(request);
+		}
+
+		/// <summary>
+		///    Asynchronously reads from 1 to 2000 contiguous discrete input status.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of discrete inputs to read.</param>
+		/// <returns>A task that represents the asynchronous read operation.</returns>
+		public Task<bool[]> ReadInputsAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+		{
+			ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 2000);
+
+			var request = new ReadCoilsInputsRequest(
+					ModbusFunctionCodes.ReadInputs,
+					slaveAddress,
+					startAddress,
+					numberOfPoints);
+
+			return PerformReadDiscretesAsync(request);
+		}
+
+		/// <summary>
+		///    Reads contiguous block of holding registers.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of holding registers to read.</param>
+		/// <returns>Holding registers status.</returns>
+		public ushort[] ReadHoldingRegisters(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+		{
+			ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 125);
+
+			var request = new ReadHoldingInputRegistersRequest(
+					ModbusFunctionCodes.ReadHoldingRegisters,
+					slaveAddress,
+					startAddress,
+					numberOfPoints);
+
+			return PerformReadRegisters(request);
+		}
+
+		/// <summary>
+		///    Reads contiguous block of holding registers.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of holding registers to read.</param>
+		/// <returns>Holding registers status.</returns>
+		public uint[] ReadHoldingRegisters32(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+		{
+			ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 62);
+
+			var request = new ReadHoldingInputRegisters32Request(
+					ModbusFunctionCodes.ReadHoldingRegisters,
+					slaveAddress,
+					startAddress,
+					numberOfPoints);
+
+			return PerformReadRegisters(request);
+		}
+
+		/// <summary>
+		///    Asynchronously reads contiguous block of holding registers.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of holding registers to read.</param>
+		/// <returns>A task that represents the asynchronous read operation.</returns>
+		public Task<ushort[]> ReadHoldingRegistersAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+		{
+			ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 125);
+
+			var request = new ReadHoldingInputRegistersRequest(
+					ModbusFunctionCodes.ReadHoldingRegisters,
+					slaveAddress,
+					startAddress,
+					numberOfPoints);
+
+			return PerformReadRegistersAsync(request);
+		}
+
+		/// <summary>
+		///    Asynchronously reads contiguous block of holding registers.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of holding registers to read.</param>
+		/// <returns>A task that represents the asynchronous read operation.</returns>
+		public Task<uint[]> ReadHoldingRegisters32Async(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+		{
+			ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 125);
+
+			var request = new ReadHoldingInputRegisters32Request(
+					ModbusFunctionCodes.ReadHoldingRegisters,
+					slaveAddress,
+					startAddress,
+					numberOfPoints);
+
+			return PerformReadRegistersAsync(request);
+		}
+
+		/// <summary>
+		///    Reads contiguous block of input registers.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of holding registers to read.</param>
+		/// <returns>Input registers status.</returns>
+		public ushort[] ReadInputRegisters(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+		{
+			ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 125);
+
+			var request = new ReadHoldingInputRegistersRequest(
+					ModbusFunctionCodes.ReadInputRegisters,
+					slaveAddress,
+					startAddress,
+					numberOfPoints);
+
+			return PerformReadRegisters(request);
+		}
+
+		/// <summary>
+		///    Reads contiguous block of input registers with 32 bit register size.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of holding registers to read.</param>
+		/// <returns>Input registers status.</returns>
+		public uint[] ReadInputRegisters32(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+		{
+			ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 62);
+
+			var request = new ReadHoldingInputRegisters32Request(
+					ModbusFunctionCodes.ReadInputRegisters,
+					slaveAddress,
+					startAddress,
+					numberOfPoints);
+
+			return PerformReadRegisters(request);
+		}
+
+		/// <summary>
+		///    Asynchronously reads contiguous block of input registers.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of holding registers to read.</param>
+		/// <returns>A task that represents the asynchronous read operation.</returns>
+		public Task<ushort[]> ReadInputRegistersAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+		{
+			ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 125);
+
+			var request = new ReadHoldingInputRegistersRequest(
+					ModbusFunctionCodes.ReadInputRegisters,
+					slaveAddress,
+					startAddress,
+					numberOfPoints);
+
+			return PerformReadRegistersAsync(request);
+		}
+
+		/// <summary>
+		///    Asynchronously reads contiguous block of input registers with 32 bit register size.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of holding registers to read.</param>
+		/// <returns>A task that represents the asynchronous read operation.</returns>
+		public Task<uint[]> ReadInputRegisters32Async(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+		{
+			ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 125);
+
+			var request = new ReadHoldingInputRegisters32Request(
+					ModbusFunctionCodes.ReadInputRegisters,
+					slaveAddress,
+					startAddress,
+					numberOfPoints);
+
+			return PerformReadRegistersAsync(request);
+		}
+
+		/// <summary>
+		///    Writes a single coil value.
+		/// </summary>
+		/// <param name="slaveAddress">Address of the device to write to.</param>
+		/// <param name="coilAddress">Address to write value to.</param>
+		/// <param name="value">Value to write.</param>
+		public void WriteSingleCoil(byte slaveAddress, ushort coilAddress, bool value)
+		{
+			var request = new WriteSingleCoilRequestResponse(slaveAddress, coilAddress, value);
+			Transport.UnicastMessage<WriteSingleCoilRequestResponse>(request);
+		}
+
+		/// <summary>
+		///    Asynchronously writes a single coil value.
+		/// </summary>
+		/// <param name="slaveAddress">Address of the device to write to.</param>
+		/// <param name="coilAddress">Address to write value to.</param>
+		/// <param name="value">Value to write.</param>
+		/// <returns>A task that represents the asynchronous write operation.</returns>
+		public Task WriteSingleCoilAsync(byte slaveAddress, ushort coilAddress, bool value)
+		{
+			var request = new WriteSingleCoilRequestResponse(slaveAddress, coilAddress, value);
+			return PerformWriteRequestAsync<WriteSingleCoilRequestResponse>(request);
+		}
+
+		/// <summary>
+		///    Writes a single holding register.
+		/// </summary>
+		/// <param name="slaveAddress">Address of the device to write to.</param>
+		/// <param name="registerAddress">Address to write.</param>
+		/// <param name="value">Value to write.</param>
+		public void WriteSingleRegister(byte slaveAddress, ushort registerAddress, ushort value)
+		{
+			var request = new WriteSingleRegisterRequestResponse(
+					slaveAddress,
+					registerAddress,
+					value);
+
+			Transport.UnicastMessage<WriteSingleRegisterRequestResponse>(request);
+		}
+
+		/// <summary>
+		///    Asynchronously writes a single holding register.
+		/// </summary>
+		/// <param name="slaveAddress">Address of the device to write to.</param>
+		/// <param name="registerAddress">Address to write.</param>
+		/// <param name="value">Value to write.</param>
+		/// <returns>A task that represents the asynchronous write operation.</returns>
+		public Task WriteSingleRegisterAsync(byte slaveAddress, ushort registerAddress, ushort value)
+		{
+			var request = new WriteSingleRegisterRequestResponse(
+					slaveAddress,
+					registerAddress,
+					value);
+
+			return PerformWriteRequestAsync<WriteSingleRegisterRequestResponse>(request);
+		}
+
+		/// <summary>
+		///     Write a block of 1 to 123 contiguous 16 bit holding registers.
+		/// </summary>
+		/// <param name="slaveAddress">Address of the device to write to.</param>
+		/// <param name="startAddress">Address to begin writing values.</param>
+		/// <param name="data">Values to write.</param>
+		public void WriteMultipleRegisters(byte slaveAddress, ushort startAddress, ushort[] data)
+		{
+			ValidateData("data", data, 123);
+
+			var request = new WriteMultipleRegistersRequest(
+					slaveAddress,
+					startAddress,
+					new RegisterCollection(data));
+
+			Transport.UnicastMessage<WriteMultipleRegistersResponse>(request);
+		}
+
+		/// <summary>
+		///    Asynchronously writes a block of 1 to 123 contiguous registers.
+		/// </summary>
+		/// <param name="slaveAddress">Address of the device to write to.</param>
+		/// <param name="startAddress">Address to begin writing values.</param>
+		/// <param name="data">Values to write.</param>
+		/// <returns>A task that represents the asynchronous write operation.</returns>
+		public Task WriteMultipleRegistersAsync(byte slaveAddress, ushort startAddress, ushort[] data)
+		{
+			ValidateData("data", data, 123);
+
+			var request = new WriteMultipleRegistersRequest(
+					slaveAddress,
+					startAddress,
+					new RegisterCollection(data));
+
+			return PerformWriteRequestAsync<WriteMultipleRegistersResponse>(request);
+		}
+
+		/// <summary>
+		///    Writes a sequence of coils.
+		/// </summary>
+		/// <param name="slaveAddress">Address of the device to write to.</param>
+		/// <param name="startAddress">Address to begin writing values.</param>
+		/// <param name="data">Values to write.</param>
+		public void WriteMultipleCoils(byte slaveAddress, ushort startAddress, bool[] data)
+		{
+			ValidateData("data", data, 1968);
+
+			var request = new WriteMultipleCoilsRequest(
+					slaveAddress,
+					startAddress,
+					new DiscreteCollection(data));
+
+			Transport.UnicastMessage<WriteMultipleCoilsResponse>(request);
+		}
+
+		/// <summary>
+		///    Asynchronously writes a sequence of coils.
+		/// </summary>
+		/// <param name="slaveAddress">Address of the device to write to.</param>
+		/// <param name="startAddress">Address to begin writing values.</param>
+		/// <param name="data">Values to write.</param>
+		/// <returns>A task that represents the asynchronous write operation.</returns>
+		public Task WriteMultipleCoilsAsync(byte slaveAddress, ushort startAddress, bool[] data)
+		{
+			ValidateData("data", data, 1968);
+
+			var request = new WriteMultipleCoilsRequest(
+					slaveAddress,
+					startAddress,
+					new DiscreteCollection(data));
+
+			return PerformWriteRequestAsync<WriteMultipleCoilsResponse>(request);
+		}
+
+		/// <summary>
+		///    Performs a combination of one read operation and one write operation in a single Modbus transaction.
+		///    The write operation is performed before the read.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startReadAddress">Address to begin reading (Holding registers are addressed starting at 0).</param>
+		/// <param name="numberOfPointsToRead">Number of registers to read.</param>
+		/// <param name="startWriteAddress">Address to begin writing (Holding registers are addressed starting at 0).</param>
+		/// <param name="writeData">Register values to write.</param>
+		public ushort[] ReadWriteMultipleRegisters(
+				byte slaveAddress,
+				ushort startReadAddress,
+				ushort numberOfPointsToRead,
+				ushort startWriteAddress,
+				ushort[] writeData)
+		{
+			ValidateNumberOfPoints("numberOfPointsToRead", numberOfPointsToRead, 125);
+			ValidateData("writeData", writeData, 121);
+
+			var request = new ReadWriteMultipleRegistersRequest(
+					slaveAddress,
+					startReadAddress,
+					numberOfPointsToRead,
+					startWriteAddress,
+					new RegisterCollection(writeData));
+
+			return PerformReadRegisters(request);
+		}
+
+		/// <summary>
+		///    Asynchronously performs a combination of one read operation and one write operation in a single Modbus transaction.
+		///    The write operation is performed before the read.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startReadAddress">Address to begin reading (Holding registers are addressed starting at 0).</param>
+		/// <param name="numberOfPointsToRead">Number of registers to read.</param>
+		/// <param name="startWriteAddress">Address to begin writing (Holding registers are addressed starting at 0).</param>
+		/// <param name="writeData">Register values to write.</param>
+		/// <returns>A task that represents the asynchronous operation.</returns>
+		public Task<ushort[]> ReadWriteMultipleRegistersAsync(
+				byte slaveAddress,
+				ushort startReadAddress,
+				ushort numberOfPointsToRead,
+				ushort startWriteAddress,
+				ushort[] writeData)
+		{
+			ValidateNumberOfPoints("numberOfPointsToRead", numberOfPointsToRead, 125);
+			ValidateData("writeData", writeData, 121);
+
+			var request = new ReadWriteMultipleRegistersRequest(
+					slaveAddress,
+					startReadAddress,
+					numberOfPointsToRead,
+					startWriteAddress,
+					new RegisterCollection(writeData));
+
+			return PerformReadRegistersAsync(request);
+		}
+
+		/// <summary>
+		/// Write a file record to the device.
+		/// </summary>
+		/// <param name="slaveAdress">Address of device to write values to</param>
+		/// <param name="fileNumber">The Extended Memory file number</param>
+		/// <param name="startingAddress">The starting register address within the file</param>
+		/// <param name="data">The data to be written</param>
+		public void WriteFileRecord(byte slaveAdress, ushort fileNumber, ushort startingAddress, byte[] data)
+		{
+			ValidateMaxData("data", data, 244);
+			var request = new WriteFileRecordRequest(slaveAdress, new FileRecordCollection(
+					fileNumber, startingAddress, data));
+
+			Transport.UnicastMessage<WriteFileRecordResponse>(request);
+		}
+
+		/// <summary>
+		///    Executes the custom message.
+		/// </summary>
+		/// <typeparam name="TResponse">The type of the response.</typeparam>
+		/// <param name="request">The request.</param>
+		[SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter")]
+		[SuppressMessage("Microsoft.Usage", "CA2223:MembersShouldDifferByMoreThanReturnType")]
+		public TResponse ExecuteCustomMessage<TResponse>(IModbusMessage request)
+				where TResponse : IModbusMessage, new()
+		{
+			return Transport.UnicastMessage<TResponse>(request);
+		}
+
+		private static void ValidateData<T>(string argumentName, T[] data, int maxDataLength)
+		{
+			if (data == null)
+			{
+				throw new ArgumentNullException(nameof(data));
+			}
+
+			if (data.Length == 0 || data.Length > maxDataLength)
+			{
+				string msg = $"The length of argument {argumentName} must be between 1 and {maxDataLength} inclusive.";
+				throw new ArgumentException(msg);
+			}
+		}
+
+		private static void ValidateMaxData<T>(string argumentName, T[] data, int maxDataLength)
+		{
+			if (data == null)
+			{
+				throw new ArgumentNullException(nameof(data));
+			}
+
+			if (data.Length > maxDataLength)
+			{
+				string msg = $"The length of argument {argumentName} must not be greater than {maxDataLength}.";
+				throw new ArgumentException(msg);
+			}
+		}
+
+		private static void ValidateNumberOfPoints(string argumentName, ushort numberOfPoints, ushort maxNumberOfPoints)
+		{
+			if (numberOfPoints < 1 || numberOfPoints > maxNumberOfPoints)
+			{
+				string msg = $"Argument {argumentName} must be between 1 and {maxNumberOfPoints} inclusive.";
+				throw new ArgumentException(msg);
+			}
+		}
+
+		private bool[] PerformReadDiscretes(ReadCoilsInputsRequest request)
+		{
+			ReadCoilsInputsResponse response = Transport.UnicastMessage<ReadCoilsInputsResponse>(request);
+			return response.Data.Take(request.NumberOfPoints).ToArray();
+		}
+
+		private Task<bool[]> PerformReadDiscretesAsync(ReadCoilsInputsRequest request)
+		{
+			return Task.Factory.StartNew(() => PerformReadDiscretes(request));
+		}
+
+		private ushort[] PerformReadRegisters(ReadHoldingInputRegistersRequest request)
+		{
+			ReadHoldingInputRegistersResponse response =
+					Transport.UnicastMessage<ReadHoldingInputRegistersResponse>(request);
+
+			return response.Data.Take(request.NumberOfPoints).ToArray();
+		}
+
+		private uint[] PerformReadRegisters(ReadHoldingInputRegisters32Request request)
+		{
+			ReadHoldingInputRegistersResponse response =
+					Transport.UnicastMessage<ReadHoldingInputRegistersResponse>(request);
+
+			uint[] registers = new uint[request.NumberOfPoints];
+
+			if (response.Data is IModbusMessageDataCollection data)
+			{
+				for (int i = 0; i < response.Data.ByteCount; i += 4)
 				{
-					return Task.Factory.StartNew(() => PerformReadRegisters(request));
+					registers[i / 4] = (uint)(data.NetworkBytes[i + 0] << 24 | data.NetworkBytes[i + 1] << 16 | data.NetworkBytes[i + 2] << 8 | data.NetworkBytes[i + 3]);
 				}
+			}
 
-    private ushort[] PerformReadRegisters(ReadWriteMultipleRegistersRequest request)
-        {
-            ReadHoldingInputRegistersResponse response =
-                Transport.UnicastMessage<ReadHoldingInputRegistersResponse>(request);
+			return registers.Take(request.NumberOfPoints).ToArray();
+		}
 
-            return response.Data.Take(request.ReadRequest.NumberOfPoints).ToArray();
-        }
+		private Task<ushort[]> PerformReadRegistersAsync(ReadHoldingInputRegistersRequest request)
+		{
+			return Task.Factory.StartNew(() => PerformReadRegisters(request));
+		}
 
-        private Task<ushort[]> PerformReadRegistersAsync(ReadWriteMultipleRegistersRequest request)
-        {
-            return Task.Factory.StartNew(() => PerformReadRegisters(request));
-        }
+		private Task<uint[]> PerformReadRegistersAsync(ReadHoldingInputRegisters32Request request)
+		{
+			return Task.Factory.StartNew(() => PerformReadRegisters(request));
+		}
 
-        private Task PerformWriteRequestAsync<T>(IModbusMessage request)
-            where T : IModbusMessage, new()
-        {
-            return Task.Factory.StartNew(() => Transport.UnicastMessage<T>(request));
-        }
-    }
+		private ushort[] PerformReadRegisters(ReadWriteMultipleRegistersRequest request)
+		{
+			ReadHoldingInputRegistersResponse response =
+					Transport.UnicastMessage<ReadHoldingInputRegistersResponse>(request);
+
+			return response.Data.Take(request.ReadRequest.NumberOfPoints).ToArray();
+		}
+
+		private Task<ushort[]> PerformReadRegistersAsync(ReadWriteMultipleRegistersRequest request)
+		{
+			return Task.Factory.StartNew(() => PerformReadRegisters(request));
+		}
+
+		private Task PerformWriteRequestAsync<T>(IModbusMessage request)
+				where T : IModbusMessage, new()
+		{
+			return Task.Factory.StartNew(() => Transport.UnicastMessage<T>(request));
+		}
+	}
 }

--- a/NModbus/Extensions/Enron/EnronModbus.cs
+++ b/NModbus/Extensions/Enron/EnronModbus.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using NModbus.Utility;
 
 namespace NModbus.Extensions.Enron
 {
@@ -10,66 +9,7 @@ namespace NModbus.Extensions.Enron
     /// </summary>
     public static class EnronModbus
     {
-        /// <summary>
-        ///     Read contiguous block of 32 bit holding registers.
-        /// </summary>
-        /// <param name="master">The Modbus master.</param>
-        /// <param name="slaveAddress">Address of device to read values from.</param>
-        /// <param name="startAddress">Address to begin reading.</param>
-        /// <param name="numberOfPoints">Number of holding registers to read.</param>
-        /// <returns>Holding registers status</returns>
-        public static uint[] ReadHoldingRegisters32(
-            this IModbusMaster master,
-            byte slaveAddress,
-            ushort startAddress,
-            ushort numberOfPoints)
-        {
-            if (master == null)
-            {
-                throw new ArgumentNullException(nameof(master));
-            }
-
-            ValidateNumberOfPoints(numberOfPoints, 62);
-
-            // read 16 bit chunks and perform conversion
-            var rawRegisters = master.ReadHoldingRegisters(
-                slaveAddress,
-                startAddress,
-                (ushort)(numberOfPoints * 2));
-
-            return Convert(rawRegisters).ToArray();
-        }
-
-        /// <summary>
-        ///     Read contiguous block of 32 bit input registers.
-        /// </summary>
-        /// <param name="master">The Modbus master.</param>
-        /// <param name="slaveAddress">Address of device to read values from.</param>
-        /// <param name="startAddress">Address to begin reading.</param>
-        /// <param name="numberOfPoints">Number of holding registers to read.</param>
-        /// <returns>Input registers status</returns>
-        public static uint[] ReadInputRegisters32(
-            this IModbusMaster master,
-            byte slaveAddress,
-            ushort startAddress,
-            ushort numberOfPoints)
-        {
-            if (master == null)
-            {
-                throw new ArgumentNullException(nameof(master));
-            }
-
-            ValidateNumberOfPoints(numberOfPoints, 62);
-
-            var rawRegisters = master.ReadInputRegisters(
-                slaveAddress,
-                startAddress,
-                (ushort)(numberOfPoints * 2));
-
-            return Convert(rawRegisters).ToArray();
-        }
-
-        /// <summary>
+			/// <summary>
         ///     Write a single 16 bit holding register.
         /// </summary>
         /// <param name="master">The Modbus master.</param>
@@ -129,31 +69,10 @@ namespace NModbus.Extensions.Enron
             foreach (var register in registers)
             {
                 // low order value
-                yield return BitConverter.ToUInt16(BitConverter.GetBytes(register), 0);
+                yield return BitConverter.ToUInt16(BitConverter.GetBytes(register), 2);
 
                 // high order value
-                yield return BitConverter.ToUInt16(BitConverter.GetBytes(register), 2);
-            }
-        }
-
-        /// <summary>
-        ///     Convert the 16 bit registers to 32 bit registers.
-        /// </summary>
-        private static IEnumerable<uint> Convert(ushort[] registers)
-        {
-            for (int i = 0; i < registers.Length; i++)
-            {
-                yield return ModbusUtility.GetUInt32(registers[i + 1], registers[i]);
-                i++;
-            }
-        }
-
-        private static void ValidateNumberOfPoints(ushort numberOfPoints, ushort maxNumberOfPoints)
-        {
-            if (numberOfPoints < 1 || numberOfPoints > maxNumberOfPoints)
-            {
-                string msg = $"Argument numberOfPoints must be between 1 and {maxNumberOfPoints} inclusive.";
-                throw new ArgumentException(msg);
+                yield return BitConverter.ToUInt16(BitConverter.GetBytes(register), 0);
             }
         }
     }

--- a/NModbus/Extensions/Enron/EnronModbus.cs
+++ b/NModbus/Extensions/Enron/EnronModbus.cs
@@ -4,76 +4,76 @@ using System.Linq;
 
 namespace NModbus.Extensions.Enron
 {
-    /// <summary>
-    ///     Utility extensions for the Enron Modbus dialect.
-    /// </summary>
-    public static class EnronModbus
-    {
-			/// <summary>
-        ///     Write a single 16 bit holding register.
-        /// </summary>
-        /// <param name="master">The Modbus master.</param>
-        /// <param name="slaveAddress">Address of the device to write to.</param>
-        /// <param name="registerAddress">Address to write.</param>
-        /// <param name="value">Value to write.</param>
-        public static void WriteSingleRegister32(
-            this IModbusMaster master,
-            byte slaveAddress,
-            ushort registerAddress,
-            uint value)
-        {
-            if (master == null)
-            {
-                throw new ArgumentNullException(nameof(master));
-            }
+	/// <summary>
+	///     Utility extensions for the Enron Modbus dialect.
+	/// </summary>
+	public static class EnronModbus
+	{
+		/// <summary>
+		///     Write a single 16 bit holding register.
+		/// </summary>
+		/// <param name="master">The Modbus master.</param>
+		/// <param name="slaveAddress">Address of the device to write to.</param>
+		/// <param name="registerAddress">Address to write.</param>
+		/// <param name="value">Value to write.</param>
+		public static void WriteSingleRegister32(
+				this IModbusMaster master,
+				byte slaveAddress,
+				ushort registerAddress,
+				uint value)
+		{
+			if (master == null)
+			{
+				throw new ArgumentNullException(nameof(master));
+			}
 
-            master.WriteMultipleRegisters32(slaveAddress, registerAddress, new[] { value });
-        }
+			master.WriteMultipleRegisters32(slaveAddress, registerAddress, new[] { value });
+		}
 
-        /// <summary>
-        ///     Write a block of contiguous 32 bit holding registers.
-        /// </summary>
-        /// <param name="master">The Modbus master.</param>
-        /// <param name="slaveAddress">Address of the device to write to.</param>
-        /// <param name="startAddress">Address to begin writing values.</param>
-        /// <param name="data">Values to write.</param>
-        public static void WriteMultipleRegisters32(
-            this IModbusMaster master,
-            byte slaveAddress,
-            ushort startAddress,
-            uint[] data)
-        {
-            if (master == null)
-            {
-                throw new ArgumentNullException(nameof(master));
-            }
+		/// <summary>
+		///     Write a block of contiguous 32 bit holding registers.
+		/// </summary>
+		/// <param name="master">The Modbus master.</param>
+		/// <param name="slaveAddress">Address of the device to write to.</param>
+		/// <param name="startAddress">Address to begin writing values.</param>
+		/// <param name="data">Values to write.</param>
+		public static void WriteMultipleRegisters32(
+				this IModbusMaster master,
+				byte slaveAddress,
+				ushort startAddress,
+				uint[] data)
+		{
+			if (master == null)
+			{
+				throw new ArgumentNullException(nameof(master));
+			}
 
-            if (data == null)
-            {
-                throw new ArgumentNullException(nameof(data));
-            }
+			if (data == null)
+			{
+				throw new ArgumentNullException(nameof(data));
+			}
 
-            if (data.Length == 0 || data.Length > 61)
-            {
-                throw new ArgumentException("The length of argument data must be between 1 and 61 inclusive.");
-            }
+			if (data.Length == 0 || data.Length > 61)
+			{
+				throw new ArgumentException("The length of argument data must be between 1 and 61 inclusive.");
+			}
 
-            master.WriteMultipleRegisters(slaveAddress, startAddress, Convert(data).ToArray());
-        }
+			master.WriteMultipleRegisters(slaveAddress, startAddress, Convert(data).ToArray());
+		}
 
-        /// <summary>
-        ///     Convert the 32 bit registers to two 16 bit values.
-        /// </summary>
-        private static IEnumerable<ushort> Convert(uint[] registers)
-        {
-            foreach (var register in registers)
-            {
-                // low order value
-                yield return BitConverter.ToUInt16(BitConverter.GetBytes(register), 2);
+		/// <summary>
+		///     Convert the 32 bit registers to two 16 bit values.
+		/// </summary>
+		private static IEnumerable<ushort> Convert(uint[] registers)
+		{
+			foreach (var register in registers)
+			{
+				// low order value
+				yield return BitConverter.ToUInt16(BitConverter.GetBytes(register), 2);
 
-                // high order value
-                yield return BitConverter.ToUInt16(BitConverter.GetBytes(register), 0);
-            }
-        }
-    }
+				// high order value
+				yield return BitConverter.ToUInt16(BitConverter.GetBytes(register), 0);
+			}
+		}
+	}
 }

--- a/NModbus/Extensions/Enron/EnronModbus.cs
+++ b/NModbus/Extensions/Enron/EnronModbus.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
+using NModbus.Data;
+using NModbus.Message;
 
 namespace NModbus.Extensions.Enron
 {
@@ -10,6 +13,90 @@ namespace NModbus.Extensions.Enron
 	public static class EnronModbus
 	{
 		/// <summary>
+		///    Reads contiguous block of input registers with 32 bit register size.
+		/// </summary>
+		/// <param name="master">The Modbus master.</param>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of holding registers to read.</param>
+		/// <returns>Input registers status.</returns>
+		public static uint[] ReadInputRegisters32(this IModbusMaster master, byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+		{
+			ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 62);
+
+			var request = new ReadHoldingInputRegisters32Request(
+				ModbusFunctionCodes.ReadInputRegisters,
+				slaveAddress,
+				startAddress,
+				numberOfPoints);
+
+			return PerformReadRegisters(master, request);
+		}
+
+		/// <summary>
+		///    Reads contiguous block of holding registers.
+		/// </summary>
+		/// <param name="master">The Modbus master.</param>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of holding registers to read.</param>
+		/// <returns>Holding registers status.</returns>
+		public static uint[] ReadHoldingRegisters32(this IModbusMaster master, byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+		{
+			ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 62);
+
+			var request = new ReadHoldingInputRegisters32Request(
+				ModbusFunctionCodes.ReadHoldingRegisters,
+				slaveAddress,
+				startAddress,
+				numberOfPoints);
+
+			return PerformReadRegisters(master, request);
+		}
+
+		/// <summary>
+		///    Asynchronously reads contiguous block of input registers with 32 bit register size.
+		/// </summary>
+		/// <param name="master">The Modbus master.</param>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of holding registers to read.</param>
+		/// <returns>A task that represents the asynchronous read operation.</returns>
+		public static Task<uint[]> ReadInputRegisters32Async(this IModbusMaster master, byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+		{
+			ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 125);
+
+			var request = new ReadHoldingInputRegisters32Request(
+				ModbusFunctionCodes.ReadInputRegisters,
+				slaveAddress,
+				startAddress,
+				numberOfPoints);
+
+			return PerformReadRegistersAsync(master, request);
+		}
+
+		/// <summary>
+		///    Asynchronously reads contiguous block of holding registers.
+		/// </summary>
+		/// <param name="master">The Modbus master.</param>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of holding registers to read.</param>
+		/// <returns>A task that represents the asynchronous read operation.</returns>
+		public static Task<uint[]> ReadHoldingRegisters32Async(this IModbusMaster master, byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+		{
+			ValidateNumberOfPoints("numberOfPoints", numberOfPoints, 125);
+
+			var request = new ReadHoldingInputRegisters32Request(
+				ModbusFunctionCodes.ReadHoldingRegisters,
+				slaveAddress,
+				startAddress,
+				numberOfPoints);
+
+			return PerformReadRegistersAsync(master, request);
+		}
+
+		/// <summary>
 		///     Write a single 16 bit holding register.
 		/// </summary>
 		/// <param name="master">The Modbus master.</param>
@@ -17,10 +104,10 @@ namespace NModbus.Extensions.Enron
 		/// <param name="registerAddress">Address to write.</param>
 		/// <param name="value">Value to write.</param>
 		public static void WriteSingleRegister32(
-				this IModbusMaster master,
-				byte slaveAddress,
-				ushort registerAddress,
-				uint value)
+			this IModbusMaster master,
+			byte slaveAddress,
+			ushort registerAddress,
+			uint value)
 		{
 			if (master == null)
 			{
@@ -38,10 +125,10 @@ namespace NModbus.Extensions.Enron
 		/// <param name="startAddress">Address to begin writing values.</param>
 		/// <param name="data">Values to write.</param>
 		public static void WriteMultipleRegisters32(
-				this IModbusMaster master,
-				byte slaveAddress,
-				ushort startAddress,
-				uint[] data)
+			this IModbusMaster master,
+			byte slaveAddress,
+			ushort startAddress,
+			uint[] data)
 		{
 			if (master == null)
 			{
@@ -59,6 +146,37 @@ namespace NModbus.Extensions.Enron
 			}
 
 			master.WriteMultipleRegisters(slaveAddress, startAddress, Convert(data).ToArray());
+		}
+
+		private static Task<uint[]> PerformReadRegistersAsync(IModbusMaster master, ReadHoldingInputRegisters32Request request)
+		{
+			return Task.Factory.StartNew(() => PerformReadRegisters(master, request));
+		}
+
+		private static uint[] PerformReadRegisters(IModbusMaster master, ReadHoldingInputRegisters32Request request)
+		{
+			ReadHoldingInputRegistersResponse response = master.Transport.UnicastMessage<ReadHoldingInputRegistersResponse>(request);
+
+			uint[] registers = new uint[request.NumberOfPoints];
+
+			if (response.Data is IModbusMessageDataCollection data)
+			{
+				for (int i = 0; i < response.Data.ByteCount; i += 4)
+				{
+					registers[i / 4] = (uint)(data.NetworkBytes[i + 0] << 24 | data.NetworkBytes[i + 1] << 16 | data.NetworkBytes[i + 2] << 8 | data.NetworkBytes[i + 3]);
+				}
+			}
+
+			return registers.Take(request.NumberOfPoints).ToArray();
+		}
+
+		private static void ValidateNumberOfPoints(string argumentName, ushort numberOfPoints, ushort maxNumberOfPoints)
+		{
+			if (numberOfPoints < 1 || numberOfPoints > maxNumberOfPoints)
+			{
+				string msg = $"Argument {argumentName} must be between 1 and {maxNumberOfPoints} inclusive.";
+				throw new ArgumentException(msg);
+			}
 		}
 
 		/// <summary>

--- a/NModbus/Interfaces/IModbusMaster.cs
+++ b/NModbus/Interfaces/IModbusMaster.cs
@@ -59,6 +59,15 @@ namespace NModbus
         ushort[] ReadHoldingRegisters(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
 
         /// <summary>
+        ///    Reads contiguous block of holding registers with 32 bit register size.
+        /// </summary>
+        /// <param name="slaveAddress">Address of device to read values from.</param>
+        /// <param name="startAddress">Address to begin reading.</param>
+        /// <param name="numberOfPoints">Number of holding registers to read.</param>
+        /// <returns>Holding registers status.</returns>
+        uint[] ReadHoldingRegisters32(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
+
+        /// <summary>
         ///    Asynchronously reads contiguous block of holding registers.
         /// </summary>
         /// <param name="slaveAddress">Address of device to read values from.</param>
@@ -66,6 +75,15 @@ namespace NModbus
         /// <param name="numberOfPoints">Number of holding registers to read.</param>
         /// <returns>A task that represents the asynchronous read operation.</returns>
         Task<ushort[]> ReadHoldingRegistersAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
+
+        /// <summary>
+        ///    Asynchronously reads contiguous block of holding registers.
+        /// </summary>
+        /// <param name="slaveAddress">Address of device to read values from.</param>
+        /// <param name="startAddress">Address to begin reading.</param>
+        /// <param name="numberOfPoints">Number of holding registers to read.</param>
+        /// <returns>A task that represents the asynchronous read operation.</returns>
+        Task<uint[]> ReadHoldingRegisters32Async(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
 
         /// <summary>
         ///    Reads contiguous block of input registers.
@@ -76,6 +94,15 @@ namespace NModbus
         /// <returns>Input registers status.</returns>
         ushort[] ReadInputRegisters(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
 
+		    /// <summary>
+		    ///    Reads contiguous block of input registers with 32 bit register size.
+		    /// </summary>
+		    /// <param name="slaveAddress">Address of device to read values from.</param>
+		    /// <param name="startAddress">Address to begin reading.</param>
+		    /// <param name="numberOfPoints">Number of holding registers to read.</param>
+		    /// <returns>Input registers status.</returns>
+				uint[] ReadInputRegisters32(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
+
         /// <summary>
         ///    Asynchronously reads contiguous block of input registers.
         /// </summary>
@@ -84,6 +111,15 @@ namespace NModbus
         /// <param name="numberOfPoints">Number of holding registers to read.</param>
         /// <returns>A task that represents the asynchronous read operation.</returns>
         Task<ushort[]> ReadInputRegistersAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
+
+		    /// <summary>
+				///    Asynchronously reads contiguous block of input registers with 32 bit register size.
+		    /// </summary>
+		    /// <param name="slaveAddress">Address of device to read values from.</param>
+		    /// <param name="startAddress">Address to begin reading.</param>
+		    /// <param name="numberOfPoints">Number of holding registers to read.</param>
+		    /// <returns>A task that represents the asynchronous read operation.</returns>
+		    Task<uint[]> ReadInputRegisters32Async(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
 
         /// <summary>
         ///    Writes a single coil value.

--- a/NModbus/Interfaces/IModbusMaster.cs
+++ b/NModbus/Interfaces/IModbusMaster.cs
@@ -3,240 +3,240 @@ using System.Threading.Tasks;
 
 namespace NModbus
 {
-    /// <summary>
-    ///     Modbus master device.
-    /// </summary>
-    public interface IModbusMaster : IDisposable
-    {
-        /// <summary>
-        ///     Transport used by this master.
-        /// </summary>
-        IModbusTransport Transport { get; }
+	/// <summary>
+	///     Modbus master device.
+	/// </summary>
+	public interface IModbusMaster : IDisposable
+	{
+		/// <summary>
+		///     Transport used by this master.
+		/// </summary>
+		IModbusTransport Transport { get; }
 
-        /// <summary>
-        ///    Reads from 1 to 2000 contiguous coils status.
-        /// </summary>
-        /// <param name="slaveAddress">Address of device to read values from.</param>
-        /// <param name="startAddress">Address to begin reading.</param>
-        /// <param name="numberOfPoints">Number of coils to read.</param>
-        /// <returns>Coils status.</returns>
-        bool[] ReadCoils(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
+		/// <summary>
+		///    Reads from 1 to 2000 contiguous coils status.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of coils to read.</param>
+		/// <returns>Coils status.</returns>
+		bool[] ReadCoils(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
 
-        /// <summary>
-        ///    Asynchronously reads from 1 to 2000 contiguous coils status.
-        /// </summary>
-        /// <param name="slaveAddress">Address of device to read values from.</param>
-        /// <param name="startAddress">Address to begin reading.</param>
-        /// <param name="numberOfPoints">Number of coils to read.</param>
-        /// <returns>A task that represents the asynchronous read operation.</returns>
-        Task<bool[]> ReadCoilsAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
+		/// <summary>
+		///    Asynchronously reads from 1 to 2000 contiguous coils status.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of coils to read.</param>
+		/// <returns>A task that represents the asynchronous read operation.</returns>
+		Task<bool[]> ReadCoilsAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
 
-        /// <summary>
-        ///    Reads from 1 to 2000 contiguous discrete input status.
-        /// </summary>
-        /// <param name="slaveAddress">Address of device to read values from.</param>
-        /// <param name="startAddress">Address to begin reading.</param>
-        /// <param name="numberOfPoints">Number of discrete inputs to read.</param>
-        /// <returns>Discrete inputs status.</returns>
-        bool[] ReadInputs(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
+		/// <summary>
+		///    Reads from 1 to 2000 contiguous discrete input status.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of discrete inputs to read.</param>
+		/// <returns>Discrete inputs status.</returns>
+		bool[] ReadInputs(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
 
-        /// <summary>
-        ///    Asynchronously reads from 1 to 2000 contiguous discrete input status.
-        /// </summary>
-        /// <param name="slaveAddress">Address of device to read values from.</param>
-        /// <param name="startAddress">Address to begin reading.</param>
-        /// <param name="numberOfPoints">Number of discrete inputs to read.</param>
-        /// <returns>A task that represents the asynchronous read operation.</returns>
-        Task<bool[]> ReadInputsAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
+		/// <summary>
+		///    Asynchronously reads from 1 to 2000 contiguous discrete input status.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of discrete inputs to read.</param>
+		/// <returns>A task that represents the asynchronous read operation.</returns>
+		Task<bool[]> ReadInputsAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
 
-        /// <summary>
-        ///    Reads contiguous block of holding registers.
-        /// </summary>
-        /// <param name="slaveAddress">Address of device to read values from.</param>
-        /// <param name="startAddress">Address to begin reading.</param>
-        /// <param name="numberOfPoints">Number of holding registers to read.</param>
-        /// <returns>Holding registers status.</returns>
-        ushort[] ReadHoldingRegisters(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
+		/// <summary>
+		///    Reads contiguous block of holding registers.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of holding registers to read.</param>
+		/// <returns>Holding registers status.</returns>
+		ushort[] ReadHoldingRegisters(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
 
-        /// <summary>
-        ///    Reads contiguous block of holding registers with 32 bit register size.
-        /// </summary>
-        /// <param name="slaveAddress">Address of device to read values from.</param>
-        /// <param name="startAddress">Address to begin reading.</param>
-        /// <param name="numberOfPoints">Number of holding registers to read.</param>
-        /// <returns>Holding registers status.</returns>
-        uint[] ReadHoldingRegisters32(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
+		/// <summary>
+		///    Reads contiguous block of holding registers with 32 bit register size.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of holding registers to read.</param>
+		/// <returns>Holding registers status.</returns>
+		uint[] ReadHoldingRegisters32(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
 
-        /// <summary>
-        ///    Asynchronously reads contiguous block of holding registers.
-        /// </summary>
-        /// <param name="slaveAddress">Address of device to read values from.</param>
-        /// <param name="startAddress">Address to begin reading.</param>
-        /// <param name="numberOfPoints">Number of holding registers to read.</param>
-        /// <returns>A task that represents the asynchronous read operation.</returns>
-        Task<ushort[]> ReadHoldingRegistersAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
+		/// <summary>
+		///    Asynchronously reads contiguous block of holding registers.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of holding registers to read.</param>
+		/// <returns>A task that represents the asynchronous read operation.</returns>
+		Task<ushort[]> ReadHoldingRegistersAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
 
-        /// <summary>
-        ///    Asynchronously reads contiguous block of holding registers.
-        /// </summary>
-        /// <param name="slaveAddress">Address of device to read values from.</param>
-        /// <param name="startAddress">Address to begin reading.</param>
-        /// <param name="numberOfPoints">Number of holding registers to read.</param>
-        /// <returns>A task that represents the asynchronous read operation.</returns>
-        Task<uint[]> ReadHoldingRegisters32Async(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
+		/// <summary>
+		///    Asynchronously reads contiguous block of holding registers.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of holding registers to read.</param>
+		/// <returns>A task that represents the asynchronous read operation.</returns>
+		Task<uint[]> ReadHoldingRegisters32Async(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
 
-        /// <summary>
-        ///    Reads contiguous block of input registers.
-        /// </summary>
-        /// <param name="slaveAddress">Address of device to read values from.</param>
-        /// <param name="startAddress">Address to begin reading.</param>
-        /// <param name="numberOfPoints">Number of holding registers to read.</param>
-        /// <returns>Input registers status.</returns>
-        ushort[] ReadInputRegisters(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
+		/// <summary>
+		///    Reads contiguous block of input registers.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of holding registers to read.</param>
+		/// <returns>Input registers status.</returns>
+		ushort[] ReadInputRegisters(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
 
-		    /// <summary>
-		    ///    Reads contiguous block of input registers with 32 bit register size.
-		    /// </summary>
-		    /// <param name="slaveAddress">Address of device to read values from.</param>
-		    /// <param name="startAddress">Address to begin reading.</param>
-		    /// <param name="numberOfPoints">Number of holding registers to read.</param>
-		    /// <returns>Input registers status.</returns>
-				uint[] ReadInputRegisters32(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
+		/// <summary>
+		///    Reads contiguous block of input registers with 32 bit register size.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of holding registers to read.</param>
+		/// <returns>Input registers status.</returns>
+		uint[] ReadInputRegisters32(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
 
-        /// <summary>
-        ///    Asynchronously reads contiguous block of input registers.
-        /// </summary>
-        /// <param name="slaveAddress">Address of device to read values from.</param>
-        /// <param name="startAddress">Address to begin reading.</param>
-        /// <param name="numberOfPoints">Number of holding registers to read.</param>
-        /// <returns>A task that represents the asynchronous read operation.</returns>
-        Task<ushort[]> ReadInputRegistersAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
+		/// <summary>
+		///    Asynchronously reads contiguous block of input registers.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of holding registers to read.</param>
+		/// <returns>A task that represents the asynchronous read operation.</returns>
+		Task<ushort[]> ReadInputRegistersAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
 
-		    /// <summary>
-				///    Asynchronously reads contiguous block of input registers with 32 bit register size.
-		    /// </summary>
-		    /// <param name="slaveAddress">Address of device to read values from.</param>
-		    /// <param name="startAddress">Address to begin reading.</param>
-		    /// <param name="numberOfPoints">Number of holding registers to read.</param>
-		    /// <returns>A task that represents the asynchronous read operation.</returns>
-		    Task<uint[]> ReadInputRegisters32Async(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
+		/// <summary>
+		///    Asynchronously reads contiguous block of input registers with 32 bit register size.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startAddress">Address to begin reading.</param>
+		/// <param name="numberOfPoints">Number of holding registers to read.</param>
+		/// <returns>A task that represents the asynchronous read operation.</returns>
+		Task<uint[]> ReadInputRegisters32Async(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
 
-        /// <summary>
-        ///    Writes a single coil value.
-        /// </summary>
-        /// <param name="slaveAddress">Address of the device to write to.</param>
-        /// <param name="coilAddress">Address to write value to.</param>
-        /// <param name="value">Value to write.</param>
-        void WriteSingleCoil(byte slaveAddress, ushort coilAddress, bool value);
+		/// <summary>
+		///    Writes a single coil value.
+		/// </summary>
+		/// <param name="slaveAddress">Address of the device to write to.</param>
+		/// <param name="coilAddress">Address to write value to.</param>
+		/// <param name="value">Value to write.</param>
+		void WriteSingleCoil(byte slaveAddress, ushort coilAddress, bool value);
 
-        /// <summary>
-        ///    Asynchronously writes a single coil value.
-        /// </summary>
-        /// <param name="slaveAddress">Address of the device to write to.</param>
-        /// <param name="coilAddress">Address to write value to.</param>
-        /// <param name="value">Value to write.</param>
-        /// <returns>A task that represents the asynchronous write operation.</returns>
-        Task WriteSingleCoilAsync(byte slaveAddress, ushort coilAddress, bool value);
+		/// <summary>
+		///    Asynchronously writes a single coil value.
+		/// </summary>
+		/// <param name="slaveAddress">Address of the device to write to.</param>
+		/// <param name="coilAddress">Address to write value to.</param>
+		/// <param name="value">Value to write.</param>
+		/// <returns>A task that represents the asynchronous write operation.</returns>
+		Task WriteSingleCoilAsync(byte slaveAddress, ushort coilAddress, bool value);
 
-        /// <summary>
-        ///    Writes a single holding register.
-        /// </summary>
-        /// <param name="slaveAddress">Address of the device to write to.</param>
-        /// <param name="registerAddress">Address to write.</param>
-        /// <param name="value">Value to write.</param>
-        void WriteSingleRegister(byte slaveAddress, ushort registerAddress, ushort value);
+		/// <summary>
+		///    Writes a single holding register.
+		/// </summary>
+		/// <param name="slaveAddress">Address of the device to write to.</param>
+		/// <param name="registerAddress">Address to write.</param>
+		/// <param name="value">Value to write.</param>
+		void WriteSingleRegister(byte slaveAddress, ushort registerAddress, ushort value);
 
-        /// <summary>
-        ///    Asynchronously writes a single holding register.
-        /// </summary>
-        /// <param name="slaveAddress">Address of the device to write to.</param>
-        /// <param name="registerAddress">Address to write.</param>
-        /// <param name="value">Value to write.</param>
-        /// <returns>A task that represents the asynchronous write operation.</returns>
-        Task WriteSingleRegisterAsync(byte slaveAddress, ushort registerAddress, ushort value);
+		/// <summary>
+		///    Asynchronously writes a single holding register.
+		/// </summary>
+		/// <param name="slaveAddress">Address of the device to write to.</param>
+		/// <param name="registerAddress">Address to write.</param>
+		/// <param name="value">Value to write.</param>
+		/// <returns>A task that represents the asynchronous write operation.</returns>
+		Task WriteSingleRegisterAsync(byte slaveAddress, ushort registerAddress, ushort value);
 
-        /// <summary>
-        ///    Writes a block of 1 to 123 contiguous registers.
-        /// </summary>
-        /// <param name="slaveAddress">Address of the device to write to.</param>
-        /// <param name="startAddress">Address to begin writing values.</param>
-        /// <param name="data">Values to write.</param>
-        void WriteMultipleRegisters(byte slaveAddress, ushort startAddress, ushort[] data);
+		/// <summary>
+		///    Writes a block of 1 to 123 contiguous registers.
+		/// </summary>
+		/// <param name="slaveAddress">Address of the device to write to.</param>
+		/// <param name="startAddress">Address to begin writing values.</param>
+		/// <param name="data">Values to write.</param>
+		void WriteMultipleRegisters(byte slaveAddress, ushort startAddress, ushort[] data);
 
-        /// <summary>
-        ///    Asynchronously writes a block of 1 to 123 contiguous registers.
-        /// </summary>
-        /// <param name="slaveAddress">Address of the device to write to.</param>
-        /// <param name="startAddress">Address to begin writing values.</param>
-        /// <param name="data">Values to write.</param>
-        /// <returns>A task that represents the asynchronous write operation.</returns>
-        Task WriteMultipleRegistersAsync(byte slaveAddress, ushort startAddress, ushort[] data);
+		/// <summary>
+		///    Asynchronously writes a block of 1 to 123 contiguous registers.
+		/// </summary>
+		/// <param name="slaveAddress">Address of the device to write to.</param>
+		/// <param name="startAddress">Address to begin writing values.</param>
+		/// <param name="data">Values to write.</param>
+		/// <returns>A task that represents the asynchronous write operation.</returns>
+		Task WriteMultipleRegistersAsync(byte slaveAddress, ushort startAddress, ushort[] data);
 
-        /// <summary>
-        ///    Writes a sequence of coils.
-        /// </summary>
-        /// <param name="slaveAddress">Address of the device to write to.</param>
-        /// <param name="startAddress">Address to begin writing values.</param>
-        /// <param name="data">Values to write.</param>
-        void WriteMultipleCoils(byte slaveAddress, ushort startAddress, bool[] data);
+		/// <summary>
+		///    Writes a sequence of coils.
+		/// </summary>
+		/// <param name="slaveAddress">Address of the device to write to.</param>
+		/// <param name="startAddress">Address to begin writing values.</param>
+		/// <param name="data">Values to write.</param>
+		void WriteMultipleCoils(byte slaveAddress, ushort startAddress, bool[] data);
 
-        /// <summary>
-        ///    Asynchronously writes a sequence of coils.
-        /// </summary>
-        /// <param name="slaveAddress">Address of the device to write to.</param>
-        /// <param name="startAddress">Address to begin writing values.</param>
-        /// <param name="data">Values to write.</param>
-        /// <returns>A task that represents the asynchronous write operation.</returns>
-        Task WriteMultipleCoilsAsync(byte slaveAddress, ushort startAddress, bool[] data);
+		/// <summary>
+		///    Asynchronously writes a sequence of coils.
+		/// </summary>
+		/// <param name="slaveAddress">Address of the device to write to.</param>
+		/// <param name="startAddress">Address to begin writing values.</param>
+		/// <param name="data">Values to write.</param>
+		/// <returns>A task that represents the asynchronous write operation.</returns>
+		Task WriteMultipleCoilsAsync(byte slaveAddress, ushort startAddress, bool[] data);
 
-        /// <summary>
-        ///    Performs a combination of one read operation and one write operation in a single Modbus transaction.
-        ///    The write operation is performed before the read.
-        /// </summary>
-        /// <param name="slaveAddress">Address of device to read values from.</param>
-        /// <param name="startReadAddress">Address to begin reading (Holding registers are addressed starting at 0).</param>
-        /// <param name="numberOfPointsToRead">Number of registers to read.</param>
-        /// <param name="startWriteAddress">Address to begin writing (Holding registers are addressed starting at 0).</param>
-        /// <param name="writeData">Register values to write.</param>
-        ushort[] ReadWriteMultipleRegisters(
-            byte slaveAddress,
-            ushort startReadAddress,
-            ushort numberOfPointsToRead,
-            ushort startWriteAddress,
-            ushort[] writeData);
+		/// <summary>
+		///    Performs a combination of one read operation and one write operation in a single Modbus transaction.
+		///    The write operation is performed before the read.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startReadAddress">Address to begin reading (Holding registers are addressed starting at 0).</param>
+		/// <param name="numberOfPointsToRead">Number of registers to read.</param>
+		/// <param name="startWriteAddress">Address to begin writing (Holding registers are addressed starting at 0).</param>
+		/// <param name="writeData">Register values to write.</param>
+		ushort[] ReadWriteMultipleRegisters(
+				byte slaveAddress,
+				ushort startReadAddress,
+				ushort numberOfPointsToRead,
+				ushort startWriteAddress,
+				ushort[] writeData);
 
-        /// <summary>
-        ///    Asynchronously performs a combination of one read operation and one write operation in a single Modbus transaction.
-        ///    The write operation is performed before the read.
-        /// </summary>
-        /// <param name="slaveAddress">Address of device to read values from.</param>
-        /// <param name="startReadAddress">Address to begin reading (Holding registers are addressed starting at 0).</param>
-        /// <param name="numberOfPointsToRead">Number of registers to read.</param>
-        /// <param name="startWriteAddress">Address to begin writing (Holding registers are addressed starting at 0).</param>
-        /// <param name="writeData">Register values to write.</param>
-        /// <returns>A task that represents the asynchronous operation</returns>
-        Task<ushort[]> ReadWriteMultipleRegistersAsync(
-            byte slaveAddress,
-            ushort startReadAddress,
-            ushort numberOfPointsToRead,
-            ushort startWriteAddress,
-            ushort[] writeData);
+		/// <summary>
+		///    Asynchronously performs a combination of one read operation and one write operation in a single Modbus transaction.
+		///    The write operation is performed before the read.
+		/// </summary>
+		/// <param name="slaveAddress">Address of device to read values from.</param>
+		/// <param name="startReadAddress">Address to begin reading (Holding registers are addressed starting at 0).</param>
+		/// <param name="numberOfPointsToRead">Number of registers to read.</param>
+		/// <param name="startWriteAddress">Address to begin writing (Holding registers are addressed starting at 0).</param>
+		/// <param name="writeData">Register values to write.</param>
+		/// <returns>A task that represents the asynchronous operation</returns>
+		Task<ushort[]> ReadWriteMultipleRegistersAsync(
+				byte slaveAddress,
+				ushort startReadAddress,
+				ushort numberOfPointsToRead,
+				ushort startWriteAddress,
+				ushort[] writeData);
 
-        /// <summary>
-        /// Write a file record to the device.
-        /// </summary>
-        /// <param name="slaveAdress">Address of device to write values to</param>
-        /// <param name="fileNumber">The Extended Memory file number</param>
-        /// <param name="startingAddress">The starting register address within the file</param>
-        /// <param name="data">The data to be written</param>
-        void WriteFileRecord(byte slaveAdress, ushort fileNumber, ushort startingAddress, byte[] data);
+		/// <summary>
+		/// Write a file record to the device.
+		/// </summary>
+		/// <param name="slaveAdress">Address of device to write values to</param>
+		/// <param name="fileNumber">The Extended Memory file number</param>
+		/// <param name="startingAddress">The starting register address within the file</param>
+		/// <param name="data">The data to be written</param>
+		void WriteFileRecord(byte slaveAdress, ushort fileNumber, ushort startingAddress, byte[] data);
 
-        /// <summary>
-        ///    Executes the custom message.
-        /// </summary>
-        /// <typeparam name="TResponse">The type of the response.</typeparam>
-        /// <param name="request">The request.</param>
-        TResponse ExecuteCustomMessage<TResponse>(IModbusMessage request)
-            where TResponse : IModbusMessage, new();
-    }
+		/// <summary>
+		///    Executes the custom message.
+		/// </summary>
+		/// <typeparam name="TResponse">The type of the response.</typeparam>
+		/// <param name="request">The request.</param>
+		TResponse ExecuteCustomMessage<TResponse>(IModbusMessage request)
+				where TResponse : IModbusMessage, new();
+	}
 }

--- a/NModbus/Interfaces/IModbusMaster.cs
+++ b/NModbus/Interfaces/IModbusMaster.cs
@@ -59,15 +59,6 @@ namespace NModbus
 		ushort[] ReadHoldingRegisters(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
 
 		/// <summary>
-		///    Reads contiguous block of holding registers with 32 bit register size.
-		/// </summary>
-		/// <param name="slaveAddress">Address of device to read values from.</param>
-		/// <param name="startAddress">Address to begin reading.</param>
-		/// <param name="numberOfPoints">Number of holding registers to read.</param>
-		/// <returns>Holding registers status.</returns>
-		uint[] ReadHoldingRegisters32(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
-
-		/// <summary>
 		///    Asynchronously reads contiguous block of holding registers.
 		/// </summary>
 		/// <param name="slaveAddress">Address of device to read values from.</param>
@@ -75,15 +66,6 @@ namespace NModbus
 		/// <param name="numberOfPoints">Number of holding registers to read.</param>
 		/// <returns>A task that represents the asynchronous read operation.</returns>
 		Task<ushort[]> ReadHoldingRegistersAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
-
-		/// <summary>
-		///    Asynchronously reads contiguous block of holding registers.
-		/// </summary>
-		/// <param name="slaveAddress">Address of device to read values from.</param>
-		/// <param name="startAddress">Address to begin reading.</param>
-		/// <param name="numberOfPoints">Number of holding registers to read.</param>
-		/// <returns>A task that represents the asynchronous read operation.</returns>
-		Task<uint[]> ReadHoldingRegisters32Async(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
 
 		/// <summary>
 		///    Reads contiguous block of input registers.
@@ -95,15 +77,6 @@ namespace NModbus
 		ushort[] ReadInputRegisters(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
 
 		/// <summary>
-		///    Reads contiguous block of input registers with 32 bit register size.
-		/// </summary>
-		/// <param name="slaveAddress">Address of device to read values from.</param>
-		/// <param name="startAddress">Address to begin reading.</param>
-		/// <param name="numberOfPoints">Number of holding registers to read.</param>
-		/// <returns>Input registers status.</returns>
-		uint[] ReadInputRegisters32(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
-
-		/// <summary>
 		///    Asynchronously reads contiguous block of input registers.
 		/// </summary>
 		/// <param name="slaveAddress">Address of device to read values from.</param>
@@ -111,15 +84,6 @@ namespace NModbus
 		/// <param name="numberOfPoints">Number of holding registers to read.</param>
 		/// <returns>A task that represents the asynchronous read operation.</returns>
 		Task<ushort[]> ReadInputRegistersAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
-
-		/// <summary>
-		///    Asynchronously reads contiguous block of input registers with 32 bit register size.
-		/// </summary>
-		/// <param name="slaveAddress">Address of device to read values from.</param>
-		/// <param name="startAddress">Address to begin reading.</param>
-		/// <param name="numberOfPoints">Number of holding registers to read.</param>
-		/// <returns>A task that represents the asynchronous read operation.</returns>
-		Task<uint[]> ReadInputRegisters32Async(byte slaveAddress, ushort startAddress, ushort numberOfPoints);
 
 		/// <summary>
 		///    Writes a single coil value.

--- a/NModbus/Message/ReadHoldingInputRegisters32Request.cs
+++ b/NModbus/Message/ReadHoldingInputRegisters32Request.cs
@@ -1,0 +1,32 @@
+﻿using System.Diagnostics;
+using System.IO;
+
+namespace NModbus.Message
+{
+  internal class ReadHoldingInputRegisters32Request : ReadHoldingInputRegistersRequest
+  {
+    public ReadHoldingInputRegisters32Request()
+    {
+    }
+
+    public ReadHoldingInputRegisters32Request(byte functionCode, byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+        : base(functionCode, slaveAddress, startAddress, numberOfPoints)
+    {
+      StartAddress = startAddress;
+      NumberOfPoints = numberOfPoints;
+    }
+
+    public override void ValidateResponse(IModbusMessage response)
+    {
+      var typedResponse = response as ReadHoldingInputRegistersResponse;
+      Debug.Assert(typedResponse != null, "Argument response should be of type ReadHoldingInputRegistersResponse.");
+      var expectedByteCount = NumberOfPoints * 4;
+
+      if (expectedByteCount != typedResponse.ByteCount)
+      {
+        string msg = $"Unexpected byte count. Expected {expectedByteCount}, received {typedResponse.ByteCount}.";
+        throw new IOException(msg);
+      }
+    }
+  }
+}

--- a/NModbus/Message/ReadHoldingInputRegistersRequest.cs
+++ b/NModbus/Message/ReadHoldingInputRegistersRequest.cs
@@ -48,7 +48,7 @@ namespace NModbus.Message
             return msg;
         }
 
-        public void ValidateResponse(IModbusMessage response)
+        public virtual void ValidateResponse(IModbusMessage response)
         {
             var typedResponse = response as ReadHoldingInputRegistersResponse;
             Debug.Assert(typedResponse != null, "Argument response should be of type ReadHoldingInputRegistersResponse.");

--- a/Samples/Program.cs
+++ b/Samples/Program.cs
@@ -5,6 +5,7 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using NModbus;
+using NModbus.Extensions.Enron;
 using NModbus.Serial;
 using NModbus.Utility;
 
@@ -30,15 +31,16 @@ namespace Samples
 
             try
             {
-                ModbusSocketSerialMasterReadRegisters();
-                ModbusSocketSerialMasterWriteRegisters();
-                ModbusSocketSerialMasterReadRegisters();
+                //ModbusSocketSerialMasterReadRegisters();
+                //ModbusSocketSerialMasterWriteRegisters();
+                //ModbusSocketSerialMasterReadRegisters();
                 await Task.Run(() => { });
-                //ModbusTcpMasterReadInputs();
-                //SimplePerfTest();
-                //ModbusSerialRtuMasterWriteRegisters();
-                //ModbusSerialAsciiMasterReadRegisters();
-                //ModbusTcpMasterReadInputs();
+				        //ModbusTcpMasterReadInputs();
+				        //SimplePerfTest();
+				        //ModbusSerialRtuMasterWriteRegisters();
+				        //ModbusSerialAsciiMasterReadRegisters();
+				        //ModbusTcpMasterReadInputs();
+								ModbusTcpMasterReadHoldingRegisters32();
                 //StartModbusAsciiSlave();
                 //ModbusTcpMasterReadInputsFromModbusSlave();
                 //ModbusSerialAsciiMasterReadRegistersFromModbusSlave();
@@ -136,9 +138,9 @@ namespace Samples
                 {
                     Console.WriteLine($"Input {(startAddress + i)}={registers[i]}");
                 }
-
             }
         }
+
         /// <summary>
         ///     Simple Modbus serial ASCII master read holding registers example.
         /// </summary>
@@ -205,6 +207,32 @@ namespace Samples
             // Input 103=0
             // Input 104=0
         }
+
+        /// <summary>
+        ///     Simple Modbus TCP master read inputs example.
+        /// </summary>
+        public static void ModbusTcpMasterReadHoldingRegisters32()
+        {
+            using (TcpClient client = new TcpClient("10.16.12.50", 502))
+            {
+                var factory = new ModbusFactory();
+                IModbusMaster master = factory.CreateMaster(client);
+
+
+								byte slaveId = 1;
+								ushort startAddress = 7165;
+                ushort numInputs = 5;
+								UInt32 www = 0x42c80083;
+
+								master.WriteSingleRegister32(slaveId, startAddress, www);
+								uint[] registers = master.ReadHoldingRegisters32(slaveId, startAddress, numInputs);
+
+				        for (int i = 0; i < numInputs; i++)
+				        {
+									Console.WriteLine($"Input {(startAddress + i)}={registers[i]}");
+				        }
+						}
+				}
 
         /// <summary>
         ///     Simple Modbus UDP master write coils example.


### PR DESCRIPTION
Current Enron implementation is not working. It's also described here: https://github.com/NModbus4/NModbus4/issues/80
A piece of documentation can be found here: https://simplymodbus.ca/enron_FC03.htm
Main idea is that a single register has a 32bit size. So requesting 1 register returns 4 bytes in stead of 2.

I was doubting to completely remove the EnronModbus and add remaining functions to IModbusMaster.

Implementation of pull request is tested against OMNI 6000 hardware with success.