### PR TITLE
Expose Masters property of ModbusTcpSlaveNetwork through interface

### DIFF
--- a/NModbus/Device/ModbusTcpSlaveNetwork.cs
+++ b/NModbus/Device/ModbusTcpSlaveNetwork.cs
@@ -18,7 +18,7 @@ namespace NModbus.Device
     /// <summary>
     ///     Modbus TCP slave device.
     /// </summary>
-    internal class ModbusTcpSlaveNetwork : ModbusSlaveNetwork
+    internal class ModbusTcpSlaveNetwork : ModbusSlaveNetwork, IModbusTcpSlaveNetwork
     {
         private const int TimeWaitResponse = 1000;
         private readonly object _serverLock = new object();

--- a/NModbus/Interfaces/IModbusFactory.cs
+++ b/NModbus/Interfaces/IModbusFactory.cs
@@ -79,7 +79,7 @@ namespace NModbus
         /// </summary>
         /// <param name="tcpListener"></param>
         /// <returns></returns>
-        IModbusSlaveNetwork CreateSlaveNetwork(TcpListener tcpListener);
+        IModbusTcpSlaveNetwork CreateSlaveNetwork(TcpListener tcpListener);
 
         /// <summary>
         /// Creates a UDP modbus slave network.

--- a/NModbus/Interfaces/IModbusTcpSlaveNetwork.cs
+++ b/NModbus/Interfaces/IModbusTcpSlaveNetwork.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.ObjectModel;
+using System.Net.Sockets;
+
+namespace NModbus
+{
+    /// <summary>
+    ///     Modbus TCP slave device.
+    /// </summary>
+    public interface IModbusTcpSlaveNetwork : IModbusSlaveNetwork
+    {
+        /// <summary>
+        ///     Gets the Modbus TCP Masters connected to this Modbus TCP Slave.
+        /// </summary>
+        ReadOnlyCollection<TcpClient> Masters { get; }
+    }
+}

--- a/NModbus/ModbusFactory.cs
+++ b/NModbus/ModbusFactory.cs
@@ -98,7 +98,7 @@ namespace NModbus
             return new ModbusSerialSlaveNetwork(transport, this, Logger);
         }
 
-        public IModbusSlaveNetwork CreateSlaveNetwork(TcpListener tcpListener)
+        public IModbusTcpSlaveNetwork CreateSlaveNetwork(TcpListener tcpListener)
         {
             return new ModbusTcpSlaveNetwork(tcpListener, this, Logger);
         }


### PR DESCRIPTION
Retry of PR #125 

It can be useful to keep track of the connected masters (TcpClients). Due to the explicit dependency on TcpListener, which isn't overrideable, it is currently not possible. There is a Masters property in ModbusTcpSlaveNetwork that actually keeps track of connected clients, but it is inaccessible from outside.
In the original repo (NModbus4), the Modbus Tcp class was public, but in the current repo, it is internal.

Suggesting to expose the Masters property through a IModbusTcpSlaveNetwork interface.