### PR TITLE
Fix spinlock in Modbus RTU

### DIFF
--- a/NModbus/IO/ModbusRtuTransport.cs
+++ b/NModbus/IO/ModbusRtuTransport.cs
@@ -50,11 +50,18 @@ namespace NModbus.IO
         public virtual byte[] Read(int count)
         {
             byte[] frameBytes = new byte[count];
-            int numBytesRead = 0;
+            int numBytesReadTotal = 0;
 
-            while (numBytesRead != count)
+            while (numBytesReadTotal != count)
             {
-                numBytesRead += StreamResource.Read(frameBytes, numBytesRead, count - numBytesRead);
+                int numBytesRead = StreamResource.Read(frameBytes, numBytesReadTotal, count - numBytesReadTotal);
+                
+                if (numBytesRead == 0)
+                {
+                    throw new IOException("Read resulted in 0 bytes returned.");
+                }
+                
+                numBytesReadTotal += numBytesRead;
             }
 
             return frameBytes;


### PR DESCRIPTION
The current implementation of ModbusRtuTransport.Read() will keep looping if StreamResource.Read() returns 0. However, both Socket.Receive() (used in SocketAdapter and UdpAdapter) and NetworkStream.Read() (used in TcpAdapter) will keep returning 0 when called with a connection which was already closed. This is especially problematic when using Modbus RTU over TCP on an unstable connection, since if the other party closes its socket during a read, this loop will keep spinning at 100 % thread usage forever, making the program pretty much unusable (see also #116).

All of the other instances of StreamResource.Read() are already checked for 0, this PR simply adds the check to the last one, throwing the same IO exception as those checks which were already implemented.