### PR TITLE
Fix timeouts on ModbusTcp

### DIFF
--- a/NModbus/IO/ModbusTransport.cs
+++ b/NModbus/IO/ModbusTransport.cs
@@ -186,7 +186,7 @@ namespace NModbus.IO
                     {
                         throw;
                     }
-                    else if (e is FormatException ||
+                    if (e is FormatException ||
                         e is NotImplementedException ||
                         e is TimeoutException ||
                         e is IOException)

--- a/NModbus/IO/ModbusTransport.cs
+++ b/NModbus/IO/ModbusTransport.cs
@@ -181,7 +181,8 @@ namespace NModbus.IO
                 }
                 catch (Exception e)
                 {
-                    if (e is SocketException || e.InnerException is SocketException)
+                    if ((e is SocketException socketException && socketException.SocketErrorCode != SocketError.TimedOut)
+                        || (e.InnerException is SocketException innerSocketException && innerSocketException.SocketErrorCode != SocketError.TimedOut))
                     {
                         throw;
                     }


### PR DESCRIPTION
I'm unsure why we handle the SocketException differently. But, since this change our retries didn't work anymore. So I added a bit differentiation to check if the SocketException is the result of a Tcp Timeout.

May fix #92 ; but in this issue, the exception text is bit different. Mine is: "System.IO.IOException: Unable to read data from the transport connection: Connection timed out."