### PR TITLE
InitializeUnique() must use the same hack as used in the ctor to crea…

### DIFF
--- a/NModbus/Message/ReadWriteMultipleRegistersRequest.cs
+++ b/NModbus/Message/ReadWriteMultipleRegistersRequest.cs
@@ -109,6 +109,14 @@ namespace NModbus.Message
 
             _readRequest = ModbusMessageFactory.CreateModbusMessage<ReadHoldingInputRegistersRequest>(readFrame);
             _writeRequest = ModbusMessageFactory.CreateModbusMessage<WriteMultipleRegistersRequest>(writeFrame);
+
+            // TODO: ugly hack for all ModbusSerialTransport-inheritances (ModbusIpTransport would not need this, as it implements complete different BuildMessageFrame)
+
+            // fake ByteCount, Data can hold only even number of bytes
+            ByteCount = (ProtocolDataUnit[1]);
+
+            // fake Data, as this modbusmessage does not fit ModbusMessageImpl
+            Data = new RegisterCollection(ProtocolDataUnit.Slice(2, ProtocolDataUnit.Length - 2).ToArray());
         }
     }
 }


### PR DESCRIPTION
The unit tests discovered an error. We've fixed that by:

InitializeUnique() must use the same hack as used in the ctor to create a proper message via the factory.