### PR TITLE
Fix UdpClient retries #155

### DIFF
--- a/NModbus/IO/ModbusTransport.cs
+++ b/NModbus/IO/ModbusTransport.cs
@@ -189,7 +189,8 @@ namespace NModbus.IO
                     if (e is FormatException ||
                         e is NotImplementedException ||
                         e is TimeoutException ||
-                        e is IOException)
+                        e is IOException ||
+                        e is SocketException)
                     {
                         Logger.Error($"{e.GetType().Name}, {(_retries - attempt + 1)} retries remaining - {e}");
 


### PR DESCRIPTION
This should fix retries when using an UdpClient as transport. 

UdpClient throws SocketExceptions, these were not allowed to retry. 
https://github.com/NModbus/NModbus/issues/155