### PR TITLE
Fixed sample program ModbusTcpMasterReadInputsFromModbusSlave

### DIFF
--- a/Samples/Program.cs
+++ b/Samples/Program.cs
@@ -615,6 +615,8 @@ namespace Samples
 
             IModbusSlave slave = factory.CreateSlave(slaveId);
 
+            slave.DataStore.InputRegisters.WritePoints(100, new ushort[] { 1, 2, 3, 4, 5 });
+
             network.AddSlave(slave);
 
             var listenTask = network.ListenAsync();
@@ -627,7 +629,7 @@ namespace Samples
             ushort startAddress = 100;
 
             // read five register values
-            ushort[] inputs = master.ReadInputRegisters(0, startAddress, numInputs);
+            ushort[] inputs = master.ReadInputRegisters(slaveId, startAddress, numInputs);
 
             for (int i = 0; i < numInputs; i++)
             {


### PR DESCRIPTION
I tried using this sample program and discovered that it wait indefinitely on reading the input registers because there was no slave device 0.  Changed to read on defined variable slaveId and now it works when this method is uncommented in the main function.  I also added values in the input registers so there was data to read besides zeros.