### PR TITLE
Add broadcast write support (slave address 0)

### DIFF
--- a/NModbus/Device/ModbusMaster.cs
+++ b/NModbus/Device/ModbusMaster.cs
@@ -236,6 +236,29 @@ namespace NModbus.Device
 		}
 
 		/// <summary>
+		///    Sends a broadcast write (slave address 0) of a single holding register.
+		///    No response is read. All slaves on the network process the write.
+		/// </summary>
+		/// <param name="registerAddress">Address to write.</param>
+		/// <param name="value">Value to write.</param>
+		public void BroadcastWriteSingleRegister(ushort registerAddress, ushort value)
+		{
+			var request = new WriteSingleRegisterRequestResponse(0, registerAddress, value);
+			Transport.BroadcastWrite(request);
+		}
+
+		/// <summary>
+		///    Asynchronously sends a broadcast write (slave address 0) of a single holding register.
+		///    No response is read. All slaves on the network process the write.
+		/// </summary>
+		/// <param name="registerAddress">Address to write.</param>
+		/// <param name="value">Value to write.</param>
+		public Task BroadcastWriteSingleRegisterAsync(ushort registerAddress, ushort value)
+		{
+			return Task.Run(() => BroadcastWriteSingleRegister(registerAddress, value));
+		}
+
+		/// <summary>
 		///     Write a block of 1 to 123 contiguous 16 bit holding registers.
 		/// </summary>
 		/// <param name="slaveAddress">Address of the device to write to.</param>

--- a/NModbus/IO/ModbusTransport.cs
+++ b/NModbus/IO/ModbusTransport.cs
@@ -115,6 +115,19 @@ namespace NModbus.IO
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        ///     Sends a broadcast message (address 0) without reading any response.
+        ///     Per Modbus spec, broadcast writes are processed by all slaves on the network.
+        /// </summary>
+        /// <param name="message">The message to broadcast.</param>
+        public virtual void BroadcastWrite(IModbusMessage message)
+        {
+            lock (_syncLock)
+            {
+                Write(message);
+            }
+        }
+
         public virtual T UnicastMessage<T>(IModbusMessage message)
             where T : IModbusMessage, new()
         {

--- a/NModbus/Interfaces/IModbusMaster.cs
+++ b/NModbus/Interfaces/IModbusMaster.cs
@@ -137,6 +137,23 @@ namespace NModbus
 		Task WriteMultipleRegistersAsync(byte slaveAddress, ushort startAddress, ushort[] data);
 
 		/// <summary>
+		///    Sends a broadcast write (slave address 0) of a single holding register.
+		///    No response is read. All slaves on the network process the write.
+		/// </summary>
+		/// <param name="registerAddress">Address to write.</param>
+		/// <param name="value">Value to write.</param>
+		void BroadcastWriteSingleRegister(ushort registerAddress, ushort value);
+
+		/// <summary>
+		///    Asynchronously sends a broadcast write (slave address 0) of a single holding register.
+		///    No response is read. All slaves on the network process the write.
+		/// </summary>
+		/// <param name="registerAddress">Address to write.</param>
+		/// <param name="value">Value to write.</param>
+		/// <returns>A task that represents the asynchronous write operation.</returns>
+		Task BroadcastWriteSingleRegisterAsync(ushort registerAddress, ushort value);
+
+		/// <summary>
 		///    Writes a sequence of coils.
 		/// </summary>
 		/// <param name="slaveAddress">Address of the device to write to.</param>

--- a/NModbus/Interfaces/IModbusTransport.cs
+++ b/NModbus/Interfaces/IModbusTransport.cs
@@ -19,6 +19,9 @@ namespace NModbus
 
         T UnicastMessage<T>(IModbusMessage message) where T : IModbusMessage, new();
 
+        /// <summary>Sends a broadcast message (address 0) without reading any response.</summary>
+        void BroadcastWrite(IModbusMessage message);
+
         byte[] ReadRequest();
 
         byte[] BuildMessageFrame(IModbusMessage message);


### PR DESCRIPTION
Implement Modbus broadcast write per the Modbus Application Protocol specification. Broadcast messages use slave address 0 and are processed by all slaves on the network without sending a response.

New API:
- IModbusMaster.BroadcastWriteSingleRegister(registerAddress, value)
- IModbusMaster.BroadcastWriteSingleRegisterAsync(registerAddress, value)
- IModbusTransport.BroadcastWrite(message)

The transport-level BroadcastWrite acquires the sync lock, writes the message, and returns without reading a response.