### PR TITLE
Add Read Device Identification support (function code 0x2B)

### DIFF
--- a/NModbus/Data/DeviceIdCategory.cs
+++ b/NModbus/Data/DeviceIdCategory.cs
@@ -1,0 +1,21 @@
+namespace NModbus.Data
+{
+    /// <summary>
+    ///     Specifies the category of device identification objects to read
+    ///     (Modbus Application Protocol V1.1b3, section 6.21).
+    /// </summary>
+    public enum DeviceIdCategory : byte
+    {
+        /// <summary>Basic identification: Vendor Name, Product Code, Major Minor Revision.</summary>
+        Basic = 0x01,
+
+        /// <summary>Regular identification: basic objects plus Vendor URL, Product Name, Model Name, User Application Name.</summary>
+        Regular = 0x02,
+
+        /// <summary>Extended identification: all standard objects plus vendor-specific objects (0x80+).</summary>
+        Extended = 0x03,
+
+        /// <summary>Read a single specific object by ID.</summary>
+        Individual = 0x04
+    }
+}

--- a/NModbus/Data/DeviceIdentificationHelper.cs
+++ b/NModbus/Data/DeviceIdentificationHelper.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NModbus.Data
+{
+    /// <summary>
+    /// Helper class for easier access to device ID values
+    /// </summary>
+    public static class DeviceIdentificationHelper
+    {
+        // Standard object IDs
+        public const byte VendorNameId = 0x00;
+        public const byte ProductCodeId = 0x01;
+        public const byte MajorMinorRevisionId = 0x02;
+        public const byte VendorUrlId = 0x03;
+        public const byte ProductNameId = 0x04;
+        public const byte ModelNameId = 0x05;
+        public const byte UserApplicationNameId = 0x06;
+
+        /// <summary>
+        /// Gets the vendor name from device identification objects.
+        /// </summary>
+        public static string GetVendorName(Dictionary<byte, string> objects)
+        {
+            return objects.ContainsKey(VendorNameId) ? objects[VendorNameId] : null;
+        }
+
+        /// <summary>
+        /// Gets the product code from device identification objects.
+        /// </summary>
+        public static string GetProductCode(Dictionary<byte, string> objects)
+        {
+            return objects.ContainsKey(ProductCodeId) ? objects[ProductCodeId] : null;
+        }
+
+        /// <summary>
+        /// Gets the version from device identification objects.
+        /// </summary>
+        public static string GetVersion(Dictionary<byte, string> objects)
+        {
+            return objects.ContainsKey(MajorMinorRevisionId) ? objects[MajorMinorRevisionId] : null;
+        }
+    }
+}

--- a/NModbus/Device/MessageHandlers/ReadDeviceIdentificationService.cs
+++ b/NModbus/Device/MessageHandlers/ReadDeviceIdentificationService.cs
@@ -1,0 +1,50 @@
+using NModbus.Message;
+
+namespace NModbus.Device.MessageHandlers
+{
+    /// <summary>
+    ///     Service handler for Modbus function code 0x2B (Read Device Identification).
+    /// </summary>
+    public class ReadDeviceIdentificationService : IModbusFunctionService
+    {
+        /// <summary>Gets the function code (0x2B / 43).</summary>
+        public byte FunctionCode => ModbusFunctionCodes.ReadDeviceIdentification;
+
+        /// <summary>Creates a request message from the raw frame.</summary>
+        public IModbusMessage CreateRequest(byte[] frame)
+        {
+            var request = new ReadDeviceIdRequest();
+            request.Initialize(frame);
+            return request;
+        }
+
+        /// <summary>
+        ///     Gets the number of remaining bytes to read for a request frame.
+        ///     Device ID request is fixed-length: 5 bytes total (SlaveAddr + FC + MEI + Category + ObjectId).
+        /// </summary>
+        public int GetRtuRequestBytesToRead(byte[] frameStart)
+        {
+            return 5 - frameStart.Length;
+        }
+
+        /// <summary>
+        ///     Gets the number of remaining bytes to read for a response frame.
+        ///     Returns -1 because Device ID responses are variable-length and must be
+        ///     handled by the transport layer with custom frame reading.
+        /// </summary>
+        public int GetRtuResponseBytesToRead(byte[] frameStart)
+        {
+            return -1;
+        }
+
+        /// <summary>
+        ///     Slave-side request handling is not implemented.
+        ///     This service is for master (client) use only.
+        /// </summary>
+        public IModbusMessage HandleSlaveRequest(IModbusMessage request, ISlaveDataStore dataStore)
+        {
+            throw new System.NotImplementedException(
+                "Device ID slave-side handling is not implemented.");
+        }
+    }
+}

--- a/NModbus/Device/ModbusMaster.cs
+++ b/NModbus/Device/ModbusMaster.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
@@ -395,6 +396,56 @@ namespace NModbus.Device
 				where TResponse : IModbusMessage, new()
 		{
 			return Transport.UnicastMessage<TResponse>(request);
+		}
+
+		/// <summary>
+		///    Reads device identification objects from a Modbus slave
+		///    (function code 0x2B, MEI type 0x0E).
+		/// </summary>
+		/// <param name="slaveAddress">Address of the device to read from.</param>
+		/// <param name="category">The category of identification objects to read.</param>
+		/// <param name="objectId">The first object ID to read.</param>
+		/// <returns>A dictionary mapping object IDs to their string values.</returns>
+		public Dictionary<byte, string> ReadDeviceIdentification(byte slaveAddress,
+			DeviceIdCategory category, byte objectId)
+		{
+			var request = new ReadDeviceIdRequest(slaveAddress, category, objectId);
+			var response = Transport.UnicastMessage<ReadDeviceIdResponse>(request);
+			return response.Objects;
+		}
+
+		/// <summary>
+		///    Asynchronously reads device identification objects from a Modbus slave.
+		/// </summary>
+		/// <param name="slaveAddress">Address of the device to read from.</param>
+		/// <param name="category">The category of identification objects to read.</param>
+		/// <param name="objectId">The first object ID to read.</param>
+		/// <returns>A task containing a dictionary mapping object IDs to their string values.</returns>
+		public Task<Dictionary<byte, string>> ReadDeviceIdentificationAsync(byte slaveAddress,
+			DeviceIdCategory category, byte objectId)
+		{
+			return Task.Run(() => ReadDeviceIdentification(slaveAddress, category, objectId));
+		}
+
+		/// <summary>
+		///    Reads basic device identification (vendor name, product code, revision)
+		///    from a Modbus slave.
+		/// </summary>
+		/// <param name="slaveAddress">Address of the device to read from.</param>
+		/// <returns>A dictionary mapping object IDs to their string values.</returns>
+		public Dictionary<byte, string> ReadBasicDeviceIdentification(byte slaveAddress)
+		{
+			return ReadDeviceIdentification(slaveAddress, DeviceIdCategory.Basic, 0x00);
+		}
+
+		/// <summary>
+		///    Asynchronously reads basic device identification from a Modbus slave.
+		/// </summary>
+		/// <param name="slaveAddress">Address of the device to read from.</param>
+		/// <returns>A task containing a dictionary mapping object IDs to their string values.</returns>
+		public Task<Dictionary<byte, string>> ReadBasicDeviceIdentificationAsync(byte slaveAddress)
+		{
+			return Task.Run(() => ReadBasicDeviceIdentification(slaveAddress));
 		}
 
 		private static void ValidateData<T>(string argumentName, T[] data, int maxDataLength)

--- a/NModbus/IO/EnhancedModbusRtuTransport.cs
+++ b/NModbus/IO/EnhancedModbusRtuTransport.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NModbus.Logging;
+using NModbus.Message;
+using NModbus.Utility;
+
+namespace NModbus.IO
+{
+    /// <summary>
+    ///     Extended RTU transport that handles variable-length responses such as
+    ///     Read Device Identification (function code 0x2B). Use
+    ///     <see cref="ModbusFactoryExtensions.CreateRtuMasterWithDeviceId"/> to
+    ///     create a master that uses this transport.
+    /// </summary>
+    internal class EnhancedModbusRtuTransport : ModbusRtuTransport
+    {
+        private const byte DeviceIdFunctionCode = ModbusFunctionCodes.ReadDeviceIdentification;
+        private const byte MeiType = 0x0E;
+
+        public EnhancedModbusRtuTransport(
+            IStreamResource streamResource,
+            IModbusFactory modbusFactory,
+            IModbusLogger logger)
+            : base(streamResource, modbusFactory, logger)
+        {
+        }
+
+        /// <summary>
+        ///     Overrides response reading to detect Device ID responses and
+        ///     read their variable-length frames correctly.
+        /// </summary>
+        public override IModbusMessage ReadResponse<T>()
+        {
+            byte[] frameStart = Read(2); // [SlaveAddress][FunctionCode]
+
+            if (frameStart[1] == DeviceIdFunctionCode)
+            {
+                byte[] fullFrame = ReadDeviceIdResponseFrame(frameStart);
+                Logger.LogFrameRx(fullFrame);
+                return CreateResponse<T>(fullFrame);
+            }
+            else if ((frameStart[1] & 0x80) == 0x80)
+            {
+                // Error response: [SlaveAddr][FC|0x80][ExceptionCode][CRC][CRC]
+                byte exceptionCode = Read(1)[0];
+                byte[] crc = Read(2);
+
+                byte[] fullFrame = new byte[5];
+                fullFrame[0] = frameStart[0];
+                fullFrame[1] = frameStart[1];
+                fullFrame[2] = exceptionCode;
+                fullFrame[3] = crc[0];
+                fullFrame[4] = crc[1];
+
+                Logger.LogFrameRx(fullFrame);
+                return CreateResponse<T>(fullFrame);
+            }
+            else
+            {
+                byte[] fullFrame = ReadStandardModbusResponse(frameStart);
+                Logger.LogFrameRx(fullFrame);
+                return CreateResponse<T>(fullFrame);
+            }
+        }
+
+        /// <summary>
+        ///     Reads a standard Modbus response after the first 2 bytes have
+        ///     already been consumed.
+        /// </summary>
+        private byte[] ReadStandardModbusResponse(byte[] frameStart)
+        {
+            var frame = new List<byte>(frameStart);
+            byte functionCode = frameStart[1];
+
+            switch (functionCode)
+            {
+                case 0x01: // Read Coils
+                case 0x02: // Read Discrete Inputs
+                case 0x03: // Read Holding Registers
+                case 0x04: // Read Input Registers
+                case 0x11: // Report Slave ID
+                case 0x17: // Read/Write Multiple Registers
+                {
+                    byte byteCount = Read(1)[0];
+                    frame.Add(byteCount);
+                    frame.AddRange(Read(byteCount));
+                    frame.AddRange(Read(2)); // CRC
+                    break;
+                }
+
+                case 0x05: // Write Single Coil
+                case 0x06: // Write Single Register
+                case 0x0F: // Write Multiple Coils
+                case 0x10: // Write Multiple Registers
+                {
+                    frame.AddRange(Read(4)); // Address + Value/Quantity
+                    frame.AddRange(Read(2)); // CRC
+                    break;
+                }
+
+                case 0x16: // Mask Write Register
+                {
+                    frame.AddRange(Read(6)); // Address + AND mask + OR mask
+                    frame.AddRange(Read(2)); // CRC
+                    break;
+                }
+
+                case 0x18: // Read FIFO Queue
+                {
+                    byte[] counts = Read(4);
+                    frame.AddRange(counts);
+                    ushort byteCount = (ushort)((counts[0] << 8) | counts[1]);
+                    if (byteCount > 2)
+                        frame.AddRange(Read(byteCount - 2));
+                    frame.AddRange(Read(2)); // CRC
+                    break;
+                }
+
+                default:
+                    throw new IOException(
+                        $"EnhancedModbusRtuTransport: unsupported function code 0x{functionCode:X2}");
+            }
+
+            return frame.ToArray();
+        }
+
+        /// <summary>
+        ///     Reads a complete Device ID response frame including CRC verification.
+        /// </summary>
+        private byte[] ReadDeviceIdResponseFrame(byte[] frameStart)
+        {
+            var frame = new List<byte>(frameStart);
+
+            // Error response check
+            if ((frameStart[1] & 0x80) == 0x80)
+            {
+                frame.Add(Read(1)[0]); // Exception code
+                frame.AddRange(Read(2)); // CRC
+                return frame.ToArray();
+            }
+
+            // Header: MEI type + Device ID code + Conformity + MoreFollows + NextObjId + NumObjects
+            byte meiType = Read(1)[0];
+            frame.Add(meiType);
+
+            if (meiType != MeiType)
+                throw new IOException($"Unexpected MEI type 0x{meiType:X2} in Device ID response.");
+
+            byte[] header = Read(5); // DeviceIdCode, Conformity, MoreFollows, NextObjId, NumObjects
+            frame.AddRange(header);
+
+            byte numberOfObjects = header[4];
+
+            // Read each object: [ObjectId][Length][Value...]
+            for (int i = 0; i < numberOfObjects; i++)
+            {
+                byte objectId = Read(1)[0];
+                frame.Add(objectId);
+
+                byte objectLength = Read(1)[0];
+                frame.Add(objectLength);
+
+                if (objectLength > 0)
+                    frame.AddRange(Read(objectLength));
+            }
+
+            // Read and verify CRC
+            byte[] crcBytes = Read(2);
+            byte[] dataFrame = frame.ToArray();
+            ushort received = (ushort)(crcBytes[0] | (crcBytes[1] << 8));
+            ushort calculated = BitConverter.ToUInt16(ModbusUtility.CalculateCrc(dataFrame), 0);
+
+            if (received != calculated)
+                throw new IOException($"Device ID response CRC mismatch. Received: 0x{received:X4}, calculated: 0x{calculated:X4}");
+
+            return dataFrame;
+        }
+    }
+}

--- a/NModbus/Interfaces/IModbusMaster.cs
+++ b/NModbus/Interfaces/IModbusMaster.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using NModbus.Data;
 
 namespace NModbus
 {
@@ -202,5 +204,34 @@ namespace NModbus
 		/// <param name="request">The request.</param>
 		TResponse ExecuteCustomMessage<TResponse>(IModbusMessage request)
 				where TResponse : IModbusMessage, new();
+
+		/// <summary>
+		///    Reads device identification objects from a Modbus slave
+		///    (function code 0x2B, MEI type 0x0E).
+		/// </summary>
+		/// <param name="slaveAddress">Address of the device to read from.</param>
+		/// <param name="category">The category of identification objects to read.</param>
+		/// <param name="objectId">The first object ID to read.</param>
+		/// <returns>A dictionary mapping object IDs to their string values.</returns>
+		Dictionary<byte, string> ReadDeviceIdentification(byte slaveAddress,
+			DeviceIdCategory category, byte objectId);
+
+		/// <summary>
+		///    Asynchronously reads device identification objects from a Modbus slave.
+		/// </summary>
+		Task<Dictionary<byte, string>> ReadDeviceIdentificationAsync(byte slaveAddress,
+			DeviceIdCategory category, byte objectId);
+
+		/// <summary>
+		///    Reads basic device identification (vendor name, product code, revision).
+		/// </summary>
+		/// <param name="slaveAddress">Address of the device to read from.</param>
+		/// <returns>A dictionary mapping object IDs to their string values.</returns>
+		Dictionary<byte, string> ReadBasicDeviceIdentification(byte slaveAddress);
+
+		/// <summary>
+		///    Asynchronously reads basic device identification.
+		/// </summary>
+		Task<Dictionary<byte, string>> ReadBasicDeviceIdentificationAsync(byte slaveAddress);
 	}
 }

--- a/NModbus/Message/ReadDeviceIdRequest.cs
+++ b/NModbus/Message/ReadDeviceIdRequest.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Linq;
+using NModbus.Data;
+
+namespace NModbus.Message
+{
+    /// <summary>
+    ///     Read Device Identification request (function code 0x2B, MEI type 0x0E).
+    ///     See Modbus Application Protocol V1.1b3, section 6.21.
+    /// </summary>
+    public class ReadDeviceIdRequest : IModbusMessage
+    {
+        /// <summary>Gets or sets the slave address.</summary>
+        public byte SlaveAddress { get; set; }
+
+        /// <summary>Gets the MEI type (always 0x0E for Device Identification).</summary>
+        public byte MeiType => 0x0E;
+
+        /// <summary>Gets or sets the device ID category to read.</summary>
+        public DeviceIdCategory ReadDeviceIdCode { get; set; }
+
+        /// <summary>Gets or sets the first object ID to read.</summary>
+        public byte ObjectId { get; set; }
+
+        /// <summary>Gets the function code (always 0x2B).</summary>
+        public byte FunctionCode
+        {
+            get => ModbusFunctionCodes.ReadDeviceIdentification;
+            set { /* Fixed function code */ }
+        }
+
+        /// <summary>Not used for Device ID requests.</summary>
+        public ushort TransactionId { get; set; }
+
+        /// <summary>Parameterless constructor for deserialization.</summary>
+        public ReadDeviceIdRequest() { }
+
+        /// <summary>
+        ///     Creates a new Read Device Identification request.
+        /// </summary>
+        /// <param name="slaveAddress">The slave address (1-247).</param>
+        /// <param name="category">The device ID category to read.</param>
+        /// <param name="objectId">The first object ID to read.</param>
+        public ReadDeviceIdRequest(byte slaveAddress, DeviceIdCategory category, byte objectId)
+        {
+            SlaveAddress = slaveAddress;
+            ReadDeviceIdCode = category;
+            ObjectId = objectId;
+        }
+
+        /// <summary>Gets the complete message frame including slave address.</summary>
+        public byte[] MessageFrame => new byte[]
+        {
+            SlaveAddress,
+            FunctionCode,
+            MeiType,
+            (byte)ReadDeviceIdCode,
+            ObjectId
+        };
+
+        /// <summary>Gets the protocol data unit (frame without slave address).</summary>
+        public byte[] ProtocolDataUnit => MessageFrame.Skip(1).ToArray();
+
+        /// <summary>Initializes the request from a raw frame.</summary>
+        /// <param name="frame">The raw frame (minimum 5 bytes).</param>
+        /// <exception cref="FormatException">Thrown when the frame is too short or has an invalid function code.</exception>
+        public void Initialize(byte[] frame)
+        {
+            if (frame == null || frame.Length < 5)
+                throw new FormatException("Device ID request frame too short (minimum 5 bytes).");
+
+            SlaveAddress = frame[0];
+
+            if (frame[1] != ModbusFunctionCodes.ReadDeviceIdentification)
+                throw new FormatException($"Invalid function code. Expected 0x{ModbusFunctionCodes.ReadDeviceIdentification:X2}, got 0x{frame[1]:X2}.");
+
+            ReadDeviceIdCode = (DeviceIdCategory)frame[3];
+            ObjectId = frame[4];
+        }
+    }
+}

--- a/NModbus/Message/ReadDeviceIdResponse.cs
+++ b/NModbus/Message/ReadDeviceIdResponse.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NModbus.Data;
+
+namespace NModbus.Message
+{
+    /// <summary>
+    ///     Response to a Read Device Identification request (function code 0x2B, MEI type 0x0E).
+    ///     Parses variable-length object data from the response frame.
+    /// </summary>
+    public class ReadDeviceIdResponse : IModbusMessage
+    {
+        private const byte MaxObjectCount = 128;
+
+        /// <summary>Gets or sets the slave address.</summary>
+        public byte SlaveAddress { get; set; }
+
+        /// <summary>Gets the function code (always 0x2B).</summary>
+        public byte FunctionCode
+        {
+            get => ModbusFunctionCodes.ReadDeviceIdentification;
+            set { /* Fixed function code */ }
+        }
+
+        /// <summary>Gets the MEI type (always 0x0E for Device Identification).</summary>
+        public byte MeiType => 0x0E;
+
+        /// <summary>Gets the device ID category that was requested.</summary>
+        public DeviceIdCategory ReadDeviceIdCode { get; set; }
+
+        /// <summary>Gets the conformity level of the device.</summary>
+        public byte ConformityLevel { get; set; }
+
+        /// <summary>Gets whether more objects are available in a subsequent request.</summary>
+        public bool MoreFollows { get; set; }
+
+        /// <summary>Gets the object ID to use in the next request when <see cref="MoreFollows"/> is true.</summary>
+        public byte NextObjectId { get; set; }
+
+        /// <summary>Gets the parsed device identification objects (key = object ID, value = string).</summary>
+        public Dictionary<byte, string> Objects { get; set; } = new Dictionary<byte, string>();
+
+        /// <summary>
+        ///     The complete response frame. Stored because Device ID responses are variable-length
+        ///     and cannot be reconstructed from properties alone.
+        /// </summary>
+        public byte[] MessageFrame { get; private set; }
+
+        /// <summary>Gets the protocol data unit (frame without slave address).</summary>
+        public byte[] ProtocolDataUnit => MessageFrame?.Skip(1).ToArray();
+
+        // Standard object convenience properties
+        /// <summary>Gets the vendor name (object 0x00), or null if not present.</summary>
+        public string VendorName => Objects.ContainsKey(0x00) ? Objects[0x00] : null;
+
+        /// <summary>Gets the product code (object 0x01), or null if not present.</summary>
+        public string ProductCode => Objects.ContainsKey(0x01) ? Objects[0x01] : null;
+
+        /// <summary>Gets the major/minor revision (object 0x02), or null if not present.</summary>
+        public string MajorMinorRevision => Objects.ContainsKey(0x02) ? Objects[0x02] : null;
+
+        /// <summary>Gets the vendor URL (object 0x03), or null if not present.</summary>
+        public string VendorUrl => Objects.ContainsKey(0x03) ? Objects[0x03] : null;
+
+        /// <summary>Gets the product name (object 0x04), or null if not present.</summary>
+        public string ProductName => Objects.ContainsKey(0x04) ? Objects[0x04] : null;
+
+        /// <summary>Gets the model name (object 0x05), or null if not present.</summary>
+        public string ModelName => Objects.ContainsKey(0x05) ? Objects[0x05] : null;
+
+        /// <summary>Gets the user application name (object 0x06), or null if not present.</summary>
+        public string UserApplicationName => Objects.ContainsKey(0x06) ? Objects[0x06] : null;
+
+        /// <summary>Not used for Device ID responses.</summary>
+        public ushort TransactionId { get; set; }
+
+        /// <summary>
+        ///     Initializes the response from a raw Modbus frame.
+        /// </summary>
+        /// <param name="frame">
+        ///     The complete response frame including slave address.
+        ///     Minimum 8 bytes: [SlaveAddr][0x2B][MEI][Category][Conformity][MoreFollows][NextObjId][NumObjects]
+        /// </param>
+        /// <exception cref="FormatException">Thrown when the frame is malformed.</exception>
+        public void Initialize(byte[] frame)
+        {
+            if (frame == null)
+                throw new ArgumentNullException(nameof(frame));
+
+            MessageFrame = frame;
+
+            if (frame.Length < 8)
+                throw new FormatException($"Device ID response too short ({frame.Length} bytes, minimum 8).");
+
+            SlaveAddress = frame[0];
+
+            // Error response: MSB of function code is set (0x2B becomes 0xAB)
+            if ((frame[1] & 0x80) != 0)
+            {
+                byte exceptionCode = frame.Length > 2 ? frame[2] : (byte)0;
+                throw new SlaveException(
+                    $"Device ID exception from slave {SlaveAddress}: exception code 0x{exceptionCode:X2}");
+            }
+
+            if (frame[1] != FunctionCode)
+                throw new FormatException($"Invalid function code. Expected 0x{FunctionCode:X2}, got 0x{frame[1]:X2}.");
+
+            if (frame[2] != MeiType)
+                throw new FormatException($"Invalid MEI type. Expected 0x{MeiType:X2}, got 0x{frame[2]:X2}.");
+
+            ReadDeviceIdCode = (DeviceIdCategory)frame[3];
+            ConformityLevel = frame[4];
+            MoreFollows = frame[5] != 0x00;
+            NextObjectId = frame[6];
+
+            byte numberOfObjects = frame[7];
+            if (numberOfObjects > MaxObjectCount)
+                throw new FormatException($"Object count {numberOfObjects} exceeds maximum ({MaxObjectCount}).");
+
+            int index = 8;
+            Objects.Clear();
+
+            for (int i = 0; i < numberOfObjects; i++)
+            {
+                if (index + 2 > frame.Length)
+                    throw new FormatException("Unexpected end of frame while parsing object header.");
+
+                byte objectId = frame[index++];
+                byte objectLength = frame[index++];
+
+                if (index + objectLength > frame.Length)
+                    throw new FormatException($"Object 0x{objectId:X2} data ({objectLength} bytes) exceeds frame length.");
+
+                string objectValue = System.Text.Encoding.ASCII.GetString(frame, index, objectLength);
+                index += objectLength;
+
+                Objects[objectId] = objectValue;
+            }
+        }
+    }
+}

--- a/NModbus/ModbusFactory.cs
+++ b/NModbus/ModbusFactory.cs
@@ -29,6 +29,7 @@ namespace NModbus
             new WriteMultipleRegistersService(),
             new WriteFileRecordService(),
             new ReadWriteMultipleRegistersService(),
+            new ReadDeviceIdentificationService(),
         };
 
         private readonly IDictionary<byte, IModbusFunctionService> _functionServices;

--- a/NModbus/ModbusFactoryExtensions.cs
+++ b/NModbus/ModbusFactoryExtensions.cs
@@ -1,0 +1,30 @@
+using NModbus.IO;
+
+namespace NModbus
+{
+    /// <summary>
+    ///     Extension methods for <see cref="IModbusFactory"/> that provide enhanced transport support.
+    /// </summary>
+    public static class ModbusFactoryExtensions
+    {
+        /// <summary>
+        ///     Creates an RTU master that supports Read Device Identification (FC 0x2B)
+        ///     and other variable-length Modbus responses.
+        /// </summary>
+        /// <remarks>
+        ///     Uses <see cref="EnhancedModbusRtuTransport"/> which extends the standard
+        ///     RTU transport with dynamic frame length detection for Device Identification
+        ///     responses that cannot be determined from the response header alone.
+        /// </remarks>
+        /// <param name="factory">The Modbus factory.</param>
+        /// <param name="streamResource">The underlying serial stream resource.</param>
+        /// <returns>A serial master capable of Device ID operations.</returns>
+        public static IModbusSerialMaster CreateRtuMasterWithDeviceId(
+            this IModbusFactory factory,
+            IStreamResource streamResource)
+        {
+            var transport = new EnhancedModbusRtuTransport(streamResource, factory, factory.Logger);
+            return factory.CreateMaster(transport);
+        }
+    }
+}

--- a/NModbus/ModbusFunctionCodes.cs
+++ b/NModbus/ModbusFunctionCodes.cs
@@ -28,5 +28,8 @@
         public const byte WriteFileRecord = 21;
 
         public const byte ReadWriteMultipleRegisters = 23;
+
+        /// <summary>Read Device Identification (MEI type 0x0E).</summary>
+        public const byte ReadDeviceIdentification = 43;
     }
 }


### PR DESCRIPTION
Implement Modbus Read Device Identification (MEI type 0x0E) per Modbus Application Protocol V1.1b3, section 6.21.

New API:
- IModbusMaster.ReadDeviceIdentification(slaveAddress, category, objectId)
- IModbusMaster.ReadBasicDeviceIdentification(slaveAddress)
- Async variants of both methods

Supports all four device ID categories (Basic, Regular, Extended, Individual) and parses variable-length object responses including vendor name, product code, and revision information.

Includes EnhancedModbusRtuTransport for handling variable-length Device ID responses that cannot be determined from the response header. Use ModbusFactoryExtensions.CreateRtuMasterWithDeviceId() to create a master with Device ID support.

New files:
- Message/ReadDeviceIdRequest.cs
- Message/ReadDeviceIdResponse.cs
- Data/DeviceIdCategory.cs
- Data/DeviceIdentificationHelper.cs
- Device/MessageHandlers/ReadDeviceIdentificationService.cs
- IO/EnhancedModbusRtuTransport.cs
- ModbusFactoryExtensions.cs